### PR TITLE
docs: add requirement, backlog, and marking summaries

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,270 @@
+# Urbanova Product Backlog
+
+## Source Documents
+
+- `Project Backlog1.docx`
+- `marking scheme of CW2 for the joint school 2025.docx`
+
+## 1. Overview
+
+The current project backlog contains 25 items. The marking scheme ties functionality marks directly to backlog priority:
+
+- Priority 1: 8 items, 2 marks each, total 16 marks
+- Priority 2: 15 items, 1 mark each, total 15 marks
+- Priority 3: 2 items, 0.5 mark each, total 1 mark
+
+Backlog items are tagged as:
+
+- `F`: functional
+- `NF`: non-functional
+
+## 2. Backlog Summary Table
+
+| ID | Type | Priority | Depends On | Original Description |
+| --- | --- | --- | --- | --- |
+| 1 | F | 1 | None | Support user accounts and user login |
+| 2 | F | 2 | None | Option to store customer's card details for quicker bookings |
+| 3 | NF | 2 | 2 | If ID 2: good security for user accounts |
+| 4 | F | 1 | None | View hire options and cost: 1hr, 4hrs, 1day, 1week |
+| 5 | F | 1 | None | Book an e-scooter; select e-scooter ID and hire period. |
+| 6 | F | 1 | None | Handle card payment for booking (simulated) |
+| 7 | F | 2 | None | Send booking confirmation via email |
+| 8 | F | 1 | None | Store booking confirmation and display on demand |
+| 9 | F | 2 | 7 | (Staff) Take bookings for unregistered users (req ID 7) |
+| 10 | F | 2 | 5 | ID5: Update e-scooter status from available to unavailable |
+| 11 | F | 2 | 5 | ID5: Option to extend current booking |
+| 12 | F | 1 | None | Cancel booking |
+| 13 | F | 2 | None | Send short feedback for issues/faults |
+| 14 | F | 3 | 13 | if ID13: Prioritise feedback - escalate to high priority, resolve for low priority |
+| 15 | F | 3 | 14 | if ID14: View high priority issues |
+| 16 | F | 1 | None | Configure e-scooter details and costs. |
+| 17 | F | 2 | None | Display scooter list availability: availability/location if available |
+| 18 | F | 2 | None | Display the five scooter locations on a visual map (see sheet 2) |
+| 19 | F | 1 | None | View weekly income for rental options: 1hr, 4hr, day, week (tracking popular hire length) |
+| 20 | F | 2 | None | View combined daily income over a week duration (tracking popular hire days- include 1hr, 4hr, 1day, discount 1week hire period in this statistic) |
+| 21 | F | 2 | 19, 20 | If ID 19, 20: plot weekly income graphically |
+| 22 | F | 2 | None | Discount applied for frequent users (8+hrs per week), students, senior citizens |
+| 23 | F | 2 | None | Support usage by multiple clients simultaneously |
+| 24 | NF | 2 | None | Provide a responsive user interface |
+| 25 | NF | 2 | None | Address issues of accessibility (colour & font choices, etc) |
+
+## 3. Detailed Backlog Items
+
+### ID 1
+
+- Original description: `Support user accounts and user login`
+- Type: `F`
+- Priority: `1`
+- Depends on: `None`
+
+### ID 2
+
+- Original description: `Option to store customer's card details for quicker bookings`
+- Type: `F`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 3
+
+- Original description: `If ID 2: good security for user accounts`
+- Type: `NF`
+- Priority: `2`
+- Depends on: `ID 2`
+
+### ID 4
+
+- Original description: `View hire options and cost: 1hr, 4hrs, 1day, 1week`
+- Type: `F`
+- Priority: `1`
+- Depends on: `None`
+
+### ID 5
+
+- Original description: `Book an e-scooter; select e-scooter ID and hire period.`
+- Type: `F`
+- Priority: `1`
+- Depends on: `None`
+
+### ID 6
+
+- Original description: `Handle card payment for booking (simulated)`
+- Type: `F`
+- Priority: `1`
+- Depends on: `None`
+
+### ID 7
+
+- Original description: `Send booking confirmation via email`
+- Type: `F`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 8
+
+- Original description: `Store booking confirmation and display on demand`
+- Type: `F`
+- Priority: `1`
+- Depends on: `None`
+
+### ID 9
+
+- Original description: `(Staff) Take bookings for unregistered users (req ID 7)`
+- Type: `F`
+- Priority: `2`
+- Depends on: `ID 7`
+
+### ID 10
+
+- Original description: `ID5: Update e-scooter status from available to unavailable`
+- Type: `F`
+- Priority: `2`
+- Depends on: `ID 5`
+
+### ID 11
+
+- Original description: `ID5: Option to extend current booking`
+- Type: `F`
+- Priority: `2`
+- Depends on: `ID 5`
+
+### ID 12
+
+- Original description: `Cancel booking`
+- Type: `F`
+- Priority: `1`
+- Depends on: `None`
+
+### ID 13
+
+- Original description: `Send short feedback for issues/faults`
+- Type: `F`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 14
+
+- Original description: `if ID13: Prioritise feedback - escalate to high priority, resolve for low priority`
+- Type: `F`
+- Priority: `3`
+- Depends on: `ID 13`
+
+### ID 15
+
+- Original description: `if ID14: View high priority issues`
+- Type: `F`
+- Priority: `3`
+- Depends on: `ID 14`
+
+### ID 16
+
+- Original description: `Configure e-scooter details and costs.`
+- Type: `F`
+- Priority: `1`
+- Depends on: `None`
+
+### ID 17
+
+- Original description: `Display scooter list availability: availability/location if available`
+- Type: `F`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 18
+
+- Original description: `Display the five scooter locations on a visual map (see sheet 2)`
+- Type: `F`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 19
+
+- Original description: `View weekly income for rental options: 1hr, 4hr, day, week (tracking popular hire length)`
+- Type: `F`
+- Priority: `1`
+- Depends on: `None`
+
+### ID 20
+
+- Original description: `View combined daily income over a week duration (tracking popular hire days- include 1hr, 4hr, 1day, discount 1week hire period in this statistic)`
+- Type: `F`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 21
+
+- Original description: `If ID 19, 20: plot weekly income graphically`
+- Type: `F`
+- Priority: `2`
+- Depends on: `ID 19, ID 20`
+
+### ID 22
+
+- Original description: `Discount applied for frequent users (8+hrs per week), students, senior citizens`
+- Type: `F`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 23
+
+- Original description: `Support usage by multiple clients simultaneously`
+- Type: `F`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 24
+
+- Original description: `Provide a responsive user interface`
+- Type: `NF`
+- Priority: `2`
+- Depends on: `None`
+
+### ID 25
+
+- Original description: `Address issues of accessibility (colour & font choices, etc)`
+- Type: `NF`
+- Priority: `2`
+- Depends on: `None`
+
+## 4. Suggested Feature Grouping
+
+This grouping is an organisational aid only. The authoritative requirement remains the original backlog wording above.
+
+### 4.1 Customer booking flow
+
+- ID 1: accounts and login
+- ID 4: hire options and cost
+- ID 5: booking flow
+- ID 6: simulated payment
+- ID 8: booking confirmation storage and display
+- ID 10: scooter availability status update
+- ID 11: booking extension
+- ID 12: cancellation
+- ID 22: discounts
+
+### 4.2 Customer support and communication
+
+- ID 7: email confirmation
+- ID 13: issue or fault feedback
+- ID 14: feedback prioritisation
+- ID 15: high-priority issue view
+
+### 4.3 Operations and management
+
+- ID 9: staff booking for unregistered users
+- ID 16: configure scooter details and costs
+- ID 19: weekly income by hire option
+- ID 20: combined daily income over a week
+- ID 21: graphical income view
+
+### 4.4 Discovery and UI quality
+
+- ID 17: scooter availability listing
+- ID 18: map view of scooter locations
+- ID 23: multi-client support
+- ID 24: responsive UI
+- ID 25: accessibility
+
+## 5. Notes
+
+- The backlog file calls items `functional (F)` or `non-functional (N)`, but the table itself uses `NF` for non-functional items. This document preserves the table values.
+- Dependency relationships in this document are taken directly from wording such as `If ID 2` or `ID5`.

--- a/docs/marking-scheme.md
+++ b/docs/marking-scheme.md
@@ -1,0 +1,134 @@
+# Urbanova CW2 Marking Scheme Notes
+
+## Source Document
+
+- `marking scheme of CW2 for the joint school 2025.docx`
+
+## 1. Overall Mark Distribution
+
+Total marks: `85`
+
+- Part 1: Individual reflection, `10/85`
+- Part 2: Demonstration, `20/85`
+- Part 3: Final deliverable, `55/85`
+
+## 2. Part 1: Individual Reflection (10 marks)
+
+This personal report should be a maximum of 4 A4 pages.
+
+### 2.1 Your role in the team (5 marks)
+
+The marking scheme asks for:
+
+- your contributions and what you have done
+- your primary role based on the Belbin analysis
+- reflection on how you performed in that role
+- two specific examples from your work in the team
+
+Belbin role abbreviations listed in the scheme:
+
+- `CW`: company worker
+- `CH`: chair
+- `SH`: shaper
+- `PL`: plant
+- `RI`: resource investigator
+- `ME`: monitor/evaluator
+- `TW`: team worker
+- `CF`: completer/finisher
+
+### 2.2 Your strengths as part of the team (2 marks)
+
+The scheme asks for:
+
+- one particular area of strength
+- one example
+- how that strength benefited the team
+
+### 2.3 Your weaknesses as part of the team (3 marks)
+
+The scheme asks for:
+
+- one particular area of weakness
+- one example
+- how it impacted the team
+- how you dealt with it
+
+## 3. Part 2: Demonstration (20 marks)
+
+The scheme lists four demonstrations:
+
+- Sprint 1 demonstration: `5 marks`
+- Sprint 2 demonstration: `5 marks`
+- Sprint 3 demonstration: `5 marks`
+- Sprint 4 demonstration: `5 marks`
+
+For each sprint demonstration, marks are broken down as:
+
+- PPT slide content, demo video, PPT quality: `2 marks`
+- Presentation: `1 mark`
+- Team work, such as role division and communication: `1 mark`
+- Process management, such as wiki and version control: `1 mark`
+
+## 4. Part 3: Final Deliverable (55 marks)
+
+### 4.1 Development documents (12 marks)
+
+- Requirement report: `4 marks`
+- Design report: `4 marks`
+- Test report: `4 marks`
+
+### 4.2 Software system (43 marks)
+
+#### 4.2.1 Functionality (35 marks)
+
+Product backlog items account for `32 marks`:
+
+- Priority 1 items: `2 marks each`, `8 items`, total `16 marks`
+- Priority 2 items: `1 mark each`, `15 items`, total `15 marks`
+- Priority 3 items: `0.5 mark each`, `2 items`, total `1 mark`
+
+Other functionality and characteristics account for `3 marks`.
+
+#### 4.2.2 Development techniques and code quality (4 marks)
+
+The scheme highlights:
+
+- development technology level
+- bugs and errors
+- network security
+
+#### 4.2.3 Interface and user experience (4 marks)
+
+The provided extract explicitly lists this category as worth `4 marks`.
+
+## 5. Backlog-to-Marks Mapping
+
+The backlog items contributing directly to functionality marks are recorded in `docs/backlog.md`.
+
+Practical implication:
+
+- finishing all Priority 1 items is the fastest route to secure high-value functionality marks
+- Priority 2 items add breadth and quality
+- Priority 3 items are lower-value and should usually come after the higher-priority work
+
+## 6. Important Notes
+
+### 6.1 Sprint count mismatch
+
+There is a mismatch between the documents:
+
+- the project brief describes `three sprints`
+- the marking scheme lists `four sprint demonstrations`
+
+This should be treated as a scheduling clarification point for the team.
+
+### 6.2 Documentation matters
+
+The marking scheme allocates a meaningful portion of marks to:
+
+- requirement documentation
+- design documentation
+- test documentation
+- process management evidence such as wiki usage and version control
+
+This means the repo, docs, wiki, and issue history are part of the assessed output, not just the running software.

--- a/docs/requirement.md
+++ b/docs/requirement.md
@@ -1,0 +1,212 @@
+# Urbanova Project Requirements
+
+## Source Documents
+
+- `Project Brief.docx`
+- `Project Backlog1.docx`
+- `marking scheme of CW2 for the joint school 2025.docx`
+
+## 1. Project Overview
+
+Urbanova is an application for hiring electric scooters in the city centre. The system must support both customer operations and management operations. The brief explicitly expects a client-server architecture, persistent data storage, automated testing, and an organised Scrum-like delivery process.
+
+## 2. Product Goals
+
+### 2.1 Customer-facing goals
+
+Customers should be able to:
+
+- register and log in to the system
+- pay for a hire session or longer access period
+- make a booking and select a specific scooter
+- end or extend an active booking when supported
+- track their own usage
+- view scooter locations on a map
+- view statistics about bookings, durations, and costs
+- report issues or faults
+
+### 2.2 Management-facing goals
+
+Managers should be able to:
+
+- estimate revenue based on registered customers
+- review data for all registered customers
+- handle and resolve user-reported issues or faults
+- prioritise reported feedback
+- configure scooter prices and costs
+- offer discounts for frequent users
+
+## 3. Functional Scope
+
+The detailed functional scope is defined in the product backlog. The backlog currently contains 25 items:
+
+- Priority 1: 8 items
+- Priority 2: 15 items
+- Priority 3: 2 items
+
+The detailed list is recorded in `docs/backlog.md`.
+
+## 4. Architecture and Technical Constraints
+
+### 4.1 System architecture
+
+- The solution must use a client-server architecture.
+- The server may be monolithic or microservices-based.
+- For the highest marks, the system should cope with simultaneous connections from several clients.
+
+### 4.2 Data storage
+
+- The server should interact with a database that stores domain data such as users, bookings, routes, and dates.
+- SQL or NoSQL databases are preferred.
+- File-based storage such as CSV or JSON is acceptable but will earn fewer marks.
+- The database should be easy to run locally without special privileges or installation into system directories.
+- The brief explicitly mentions SQLite as a suitable embedded option.
+
+### 4.3 Required interfaces
+
+Two interfaces are required:
+
+- a customer interface
+- a management interface
+
+Allowed client forms:
+
+- customer interface: desktop, web, or mobile
+- management interface: desktop or web
+
+### 4.4 Web client expectations
+
+If the client is web-based, it should:
+
+- be responsive
+- be mobile friendly
+- be accessible
+- make non-trivial use of appropriate JavaScript libraries
+- not rely only on plain HTML5 and CSS3
+
+## 5. Testing, Build, and Deployment Expectations
+
+### 5.1 Testing
+
+- Testing must be part of development from the start.
+- Testing should be automated where possible.
+- The project documentation is expected to include a testing strategy.
+- The documentation should include evidence of multiple test types.
+
+### 5.2 Build and deployment
+
+- Build, test, and deployment processes should be automated as much as possible.
+- GitHub Actions is explicitly suggested as a useful option.
+- The whole system should be buildable and runnable with a minimal number of commands.
+- The application must be runnable locally for marking.
+- Cloud deployment is optional, not required.
+- A containerized version is optional extra credit.
+
+## 6. Process Requirements
+
+### 6.1 Development process
+
+- The project follows a simplified Scrum process.
+- Work is driven by a Product Owner (PO).
+- The primary development period is split into three sprints.
+- Each sprint should end with an MVP.
+
+### 6.2 Required meetings
+
+For each sprint, the team should have:
+
+- one sprint planning meeting
+- two or three short status meetings
+- one sprint review meeting
+
+Additional review expectations:
+
+- Sprint 1 and Sprint 3: report to the PO face-to-face
+- Sprint 2: receive peer feedback from two other groups and give feedback to two groups
+
+### 6.3 Scrum Master responsibilities
+
+The Scrum Master should:
+
+- organise and chair planning, review, and status meetings
+- nominate a note-taker for planning and review meetings
+- ensure notes are uploaded to the project wiki
+- maintain attendance records for all meetings in the wiki
+- investigate absences and missed deadlines on behalf of the team
+
+The brief also states:
+
+- the Scrum Master is a facilitator, not the project manager
+- the Scrum Master is also a developer
+- the Scrum Master role should ideally rotate between sprints
+
+### 6.4 Team member expectations
+
+Team members are expected to:
+
+- attend meetings or provide apologies for absences
+- use the project issue tracker for tasks, bugs, and changes
+- store other project documentation in the wiki
+- use Git for all programming activities
+- push local changes back to the remote repository regularly
+- consider collaboration practices such as pair programming for complex or critical work
+
+## 7. Repository, Issue Tracker, and Wiki Requirements
+
+### 7.1 GitHub repository
+
+- The team must use the allocated private GitHub repository.
+- Every team member is expected to make regular commits during each sprint.
+- The brief recommends agreeing on a Git workflow before Sprint 1.
+- A feature-branch workflow is explicitly recommended over pushing directly to the main branch.
+- One or more lead developers should handle merges and conflicts.
+
+### 7.2 Issue tracker
+
+The team should:
+
+- define issue labels before recording work
+- define milestones including `Sprint 1`, `Sprint 2`, `Sprint 3`, and `Final Demo`
+- assign issues to the responsible team member
+- close issues when the task is completed
+- use the tracker for tasks, bugs, and feature changes
+
+### 7.3 Wiki
+
+The wiki is described as:
+
+- the project's web site
+- the home for project-related materials not stored in the repository
+- the location for meeting notes and attendance records
+
+## 8. Delivery-Oriented Requirement Summary
+
+For this project, the team should ensure that the final solution includes:
+
+- a runnable local client-server application
+- customer and management interfaces
+- persistent domain data storage
+- a backlog-driven feature set
+- automated testing with documented strategy and evidence
+- documented requirements, design, and testing artifacts
+- a maintained issue tracker, Git history, and project wiki
+
+## 9. Important Requirement Notes and Possible Conflicts
+
+### 9.1 Discount rule conflict
+
+There is a mismatch between the brief and the backlog:
+
+- `Project Brief.docx` gives an example discount for frequent users such as `6hrs a week`
+- backlog item 22 specifies `8+hrs per week`, plus student and senior citizen discounts
+
+For implementation, the backlog item should be treated as the more concrete requirement unless the PO says otherwise.
+
+### 9.2 Sprint count vs demonstration count
+
+There is also a process mismatch:
+
+- the brief describes `three sprints`
+- the marking scheme lists `sprint 1`, `sprint 2`, `sprint 3`, and `sprint 4` demonstrations
+
+This likely means the final deliverable includes an additional final demonstration stage, but it should be confirmed with the teaching team if needed.


### PR DESCRIPTION
## Summary
- add a structured project requirement summary under `docs/requirement.md`
- add a detailed backlog reference under `docs/backlog.md`
- add a CW2 marking summary under `docs/marking-scheme.md`

## Notes
- this PR only includes the main repository `docs/` changes
- wiki updates are in the separate GitHub wiki repository and are not part of this PR