### PR TITLE
backend_sprint3

### DIFF
--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -1,26 +1,43 @@
-# Urbanova API Design (Implemented v1)
+# Urbanova API Design
 
-Last updated: 2026-04-09
+Last updated: 2026-04-25
 
-## 1. Purpose and Scope
+## 1. Scope
 
-This document describes the **currently implemented** backend APIs in this repository.
+This document describes the backend APIs that are actually implemented in the current repository.
 
-Implemented backlog/new scope:
-- ID 1: User registration & login
-- ID 4: View hire options and cost
-- ID 5: Book an e-scooter
-- ID 12: Cancel booking
-- Booking query and booking modify APIs
-- ID 16: Manager hire option and scooter management APIs
-- ID 18: Scooter map location API
-- Scooter type catalog with static image URLs
+Covered backlog:
+- ID 1: user account and login
+- ID 2: saved card details
+- ID 3: account security and admin audit support
+- ID 4: hire options and price quote
+- ID 5: booking creation
+- ID 6: simulated card payment
+- ID 7: booking confirmation and notification resend
+- ID 8: booking confirmation storage and on-demand display
+- ID 9: staff bookings for unregistered users
+- ID 10: scooter availability updates
+- ID 11: booking extension
+- ID 12: booking cancellation
+- ID 13: issue / fault submission
+- ID 14: issue prioritization and resolution
+- ID 15: high-priority issue queue
+- ID 16: manager scooter / hire / type management
+- ID 17: scooter list and availability display
+- ID 18: scooter map points
+- ID 19: weekly revenue by hire option
+- ID 20: combined daily revenue in one week
+- ID 21: weekly revenue chart payload
+- ID 22: discounts for frequent / student / senior
+- ID 23: multi-client support through transactional reservation and optimistic scooter updates
 
-Not yet implemented from the previous full design draft (examples): refresh/logout/password reset, payments, confirmations, staff APIs, analytics, issue workflow, and discount rules.
+Notes:
+- ID 24 and ID 25 are frontend concerns. No dedicated backend endpoints are required for them.
+- Extra retained endpoints also exist: `/scooters/ids`, `/scooter-types/*`, `/admin/scooter-types/*`, `/bookings/{id}` patch update.
 
-## 2. Global API Conventions
+## 2. Global Conventions
 
-### 2.1 Base URL and Version
+### 2.1 Base URL
 
 - Base URL: `/api/v1`
 
@@ -31,14 +48,23 @@ Not yet implemented from the previous full design draft (examples): refresh/logo
 
 ### 2.3 Authentication
 
-- Protected endpoints require: `Authorization: Bearer <access_token>`
-- JWT access token only (no refresh token endpoint implemented yet)
-- Default token TTL: 15 minutes (`app.jwt.expiration-minutes`)
-- Manager endpoints require authenticated user role `MANAGER`
+- Protected endpoints use `Authorization: Bearer <access_token>`
+- Access token: JWT
+- Refresh token: opaque token stored in `auth_sessions`
+- Current default access token TTL: 15 minutes
+- Current default refresh token TTL: 14 days
 
-### 2.4 Standard Response Envelope
+### 2.4 Roles
 
-All endpoints return a unified envelope:
+| Role | Meaning |
+|---|---|
+| `CUSTOMER` | registered end user |
+| `STAFF` | staff operator |
+| `MANAGER` | manager / admin |
+
+### 2.5 Standard Envelope
+
+Success:
 
 ```json
 {
@@ -46,12 +72,12 @@ All endpoints return a unified envelope:
   "data": {},
   "meta": {
     "requestId": "uuid",
-    "timestamp": "2026-04-09T05:00:00Z"
+    "timestamp": "2026-04-25T07:00:00Z"
   }
 }
 ```
 
-Error envelope:
+Failure:
 
 ```json
 {
@@ -59,65 +85,152 @@ Error envelope:
   "error": {
     "code": "VALIDATION_ERROR",
     "message": "Request validation failed",
-    "details": {
-      "field": "error message"
-    }
+    "details": {}
   },
   "meta": {
     "requestId": "uuid",
-    "timestamp": "2026-04-09T05:00:00Z"
+    "timestamp": "2026-04-25T07:00:00Z"
   }
 }
 ```
 
-### 2.5 Date/Time and Currency
+### 2.6 Date and Currency
 
-- Date-time fields are serialized from backend `LocalDateTime`
-- Currency used in pricing responses: `GBP`
+- Datetime values are serialized from backend `LocalDateTime`
+- Currency used by pricing and analytics is `GBP`
 
-### 2.6 Static Images
+## 3. Implemented Endpoint Catalog
 
-- Scooter type images are served by Spring Boot static resources
-- Current URL pattern: `/images/scooter-types/{slug}.png`
-
-## 3. Endpoint Catalog (Implemented)
+### 3.1 Authentication and User Account
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
-| POST | `/auth/register` | Public | Register customer account and issue access token |
-| POST | `/auth/login` | Public | Login and issue access token |
-| GET | `/users/me` | Bearer token | Get current user profile |
-| GET | `/hire-options` | Public | List active hire options |
-| POST | `/pricing/quotes` | Public | Quote price by hire option code |
-| POST | `/bookings` | Bearer token | Create booking for current user |
-| GET | `/bookings` | Bearer token | Query current user's bookings |
-| GET | `/bookings/{bookingId}` | Bearer token | Query booking detail |
-| PATCH | `/bookings/{bookingId}` | Bearer token | Modify booking |
-| POST | `/bookings/{bookingId}/cancel` | Bearer token | Cancel booking |
-| GET | `/scooters/ids` | Public | Query scooter IDs by scooter status |
-| GET | `/scooters/map-points` | Public | Query tracked scooter map locations with scooter type info |
-| GET | `/scooter-types` | Public | List active scooter types |
-| GET | `/scooter-types/{typeCode}` | Public | Get scooter type detail |
-| GET | `/admin/scooter-types` | Bearer token (`MANAGER`) | Manager view of all scooter types |
-| POST | `/admin/scooter-types` | Bearer token (`MANAGER`) | Create scooter type |
-| PATCH | `/admin/scooter-types/{typeCode}` | Bearer token (`MANAGER`) | Update scooter type metadata |
-| DELETE | `/admin/scooter-types/{typeCode}` | Bearer token (`MANAGER`) | Disable scooter type |
-| GET | `/admin/hire-options` | Bearer token (`MANAGER`) | Manager view of all hire options |
-| POST | `/admin/hire-options` | Bearer token (`MANAGER`) | Create hire option |
-| PATCH | `/admin/hire-options/{hireOptionId}` | Bearer token (`MANAGER`) | Update hire option duration/price |
-| DELETE | `/admin/hire-options/{hireOptionId}` | Bearer token (`MANAGER`) | Disable hire option |
-| GET | `/admin/scooters` | Bearer token (`MANAGER`) | Manager inventory view |
-| POST | `/admin/scooters` | Bearer token (`MANAGER`) | Add scooter |
-| PATCH | `/admin/scooters/{scooterId}` | Bearer token (`MANAGER`) | Update scooter details |
-| PATCH | `/admin/scooters/{scooterId}/status` | Bearer token (`MANAGER`) | Override scooter status |
-| POST | `/admin/scooters/bulk-status` | Bearer token (`MANAGER`) | Bulk update scooter statuses |
+| POST | `/auth/register` | Public | Register customer and issue tokens |
+| POST | `/auth/login` | Public | Login and issue tokens |
+| POST | `/auth/refresh` | Public | Rotate refresh token and issue a new access token |
+| POST | `/auth/logout` | Bearer | Revoke current refresh session or all active sessions |
+| POST | `/auth/password/forgot` | Public | Create password reset token |
+| POST | `/auth/password/reset` | Public | Reset password with reset token |
+| GET | `/users/me` | Bearer | Current user profile |
+| PATCH | `/users/me` | Bearer | Update current user profile |
+| GET | `/users/me/usage-summary` | Bearer | Booking and spend summary for current user |
+| GET | `/admin/users` | MANAGER | List users |
+| GET | `/admin/users/{userId}` | MANAGER | User detail |
+| PATCH | `/admin/users/{userId}/status` | MANAGER | Update account status |
+| GET | `/admin/users/{userId}/bookings` | MANAGER | User booking history |
+| GET | `/admin/audit-logs` | MANAGER | Manager audit log view |
+
+### 3.2 Payment Methods
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/payment-methods` | Bearer | List current user's saved cards |
+| POST | `/payment-methods` | Bearer | Save tokenized card metadata |
+| PATCH | `/payment-methods/{paymentMethodId}` | Bearer | Update expiry / label / default |
+| DELETE | `/payment-methods/{paymentMethodId}` | Bearer | Mark payment method as removed |
+| POST | `/payment-methods/{paymentMethodId}/default` | Bearer | Set default card |
+
+### 3.3 Pricing, Hire Options, Discounts
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/hire-options` | Public | Active hire options |
+| POST | `/pricing/quotes` | Public, optional Bearer | Price quote with discount preview when token is provided |
+| GET | `/discounts/eligibility` | Bearer | Current user discount eligibility |
+| GET | `/admin/hire-options` | MANAGER | List all hire options |
+| POST | `/admin/hire-options` | MANAGER | Create hire option |
+| PATCH | `/admin/hire-options/{hireOptionId}` | MANAGER | Update hire option |
+| DELETE | `/admin/hire-options/{hireOptionId}` | MANAGER | Disable hire option |
+| GET | `/admin/discount-rules` | MANAGER | List discount rules |
+| POST | `/admin/discount-rules` | MANAGER | Create discount rule |
+| PATCH | `/admin/discount-rules/{discountRuleId}` | MANAGER | Update discount rule |
+
+### 3.4 Scooters and Map
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/scooters` | Public | Scooter list with type, location and status |
+| GET | `/scooters/{scooterId}` | Public | Scooter detail |
+| GET | `/scooters/availability` | Public | Status counts summary |
+| GET | `/scooters/ids` | Public | Scooter IDs filtered by status |
+| GET | `/scooters/map-points` | Public | Map points for tracked scooters |
+| GET | `/scooter-types` | Public | Active scooter types |
+| GET | `/scooter-types/{typeCode}` | Public | Scooter type detail |
+| GET | `/admin/scooters` | MANAGER | Admin scooter inventory |
+| POST | `/admin/scooters` | MANAGER | Create scooter |
+| PATCH | `/admin/scooters/{scooterId}` | MANAGER | Update scooter |
+| PATCH | `/admin/scooters/{scooterId}/status` | MANAGER | Override scooter status |
+| POST | `/admin/scooters/bulk-status` | MANAGER | Bulk update scooter statuses |
+| GET | `/admin/scooter-types` | MANAGER | List scooter types |
+| POST | `/admin/scooter-types` | MANAGER | Create scooter type |
+| PATCH | `/admin/scooter-types/{typeCode}` | MANAGER | Update scooter type |
+| DELETE | `/admin/scooter-types/{typeCode}` | MANAGER | Disable scooter type |
+
+### 3.5 Bookings
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| POST | `/bookings` | CUSTOMER | Create booking |
+| GET | `/bookings` | CUSTOMER | List current user's bookings |
+| GET | `/bookings/{bookingId}` | CUSTOMER | Booking detail |
+| PATCH | `/bookings/{bookingId}` | CUSTOMER | Modify booking before settlement / start |
+| POST | `/bookings/{bookingId}/start` | CUSTOMER | Start confirmed booking |
+| POST | `/bookings/{bookingId}/end` | CUSTOMER | End active booking |
+| POST | `/bookings/{bookingId}/extend` | CUSTOMER | Extend booking |
+| POST | `/bookings/{bookingId}/cancel` | CUSTOMER | Cancel booking |
+| GET | `/bookings/{bookingId}/timeline` | CUSTOMER | Booking event timeline |
+| POST | `/staff/bookings/guest` | STAFF | Create guest booking |
+| GET | `/staff/bookings/guest/{bookingId}` | STAFF/MANAGER | Guest booking detail |
+| GET | `/admin/bookings` | MANAGER | Filtered booking list |
+| GET | `/admin/bookings/{bookingId}` | MANAGER | Booking detail with payments and timeline |
+| PATCH | `/admin/bookings/{bookingId}/override` | MANAGER | Manager override of booking fields |
+
+### 3.6 Payments, Confirmations, Notifications
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| POST | `/bookings/{bookingId}/payments` | CUSTOMER/STAFF/MANAGER | Create simulated payment |
+| GET | `/bookings/{bookingId}/payments` | CUSTOMER/STAFF/MANAGER | Payment list for booking |
+| GET | `/payments/{paymentId}` | CUSTOMER/STAFF/MANAGER | Payment detail |
+| POST | `/payments/{paymentId}/simulate-settlement` | MANAGER | Settle a deferred payment |
+| POST | `/payments/{paymentId}/refund` | MANAGER | Refund payment partially or fully |
+| GET | `/bookings/{bookingId}/confirmation` | Bearer | Latest booking confirmation |
+| POST | `/bookings/{bookingId}/confirmation/resend` | Bearer | Resend booking confirmation |
+| GET | `/confirmations` | Bearer | Current user's confirmations |
+| GET | `/notifications` | Bearer | Current user's notifications |
+| PATCH | `/notifications/{notificationId}/read` | Bearer | Mark notification as read |
+
+### 3.7 Issues
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| POST | `/issues` | Bearer | Create issue |
+| GET | `/issues` | Bearer | List current user's issues |
+| GET | `/issues/{issueId}` | Bearer | Issue detail |
+| POST | `/issues/{issueId}/comments` | Bearer | Add issue comment |
+| GET | `/admin/issues` | MANAGER | Admin issue queue |
+| PATCH | `/admin/issues/{issueId}/priority` | MANAGER | Update issue priority |
+| PATCH | `/admin/issues/{issueId}/status` | MANAGER | Update issue status |
+| POST | `/admin/issues/{issueId}/resolve` | MANAGER | Resolve issue |
+| GET | `/admin/issues/high-priority` | MANAGER | High / critical issue queue |
+
+### 3.8 Analytics and Ops
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/admin/analytics/revenue/estimate` | MANAGER | Revenue estimate in date range |
+| GET | `/admin/analytics/revenue/weekly-by-hire-option` | MANAGER | Weekly totals grouped by hire option |
+| GET | `/admin/analytics/revenue/daily-combined` | MANAGER | Daily revenue over one week |
+| GET | `/admin/analytics/revenue/weekly-chart` | MANAGER | Chart-friendly revenue series |
+| GET | `/admin/analytics/usage/frequent-users` | MANAGER | Frequent user list |
 | GET | `/health` | Public | Health check |
+| GET | `/meta` | Public | API metadata |
 
-## 4. ID1: Auth and Account APIs
+## 4. Request Notes by Domain
 
-### 4.1 POST `/api/v1/auth/register`
+### 4.1 Auth
 
-Request:
+`POST /api/v1/auth/register`
 
 ```json
 {
@@ -128,15 +241,7 @@ Request:
 }
 ```
 
-Validation:
-- `email` required, valid email format
-- `password` required, length 8-72
-- `fullName` required, max 100 chars
-- `phone` optional, max 30 chars
-
-### 4.2 POST `/api/v1/auth/login`
-
-Request:
+`POST /api/v1/auth/login`
 
 ```json
 {
@@ -145,18 +250,16 @@ Request:
 }
 ```
 
-### 4.3 GET `/api/v1/users/me`
-
-Header:
-- `Authorization: Bearer <access_token>`
-
-### 4.4 Auth Response Payload (register/login)
+Successful auth response:
 
 ```json
 {
-  "accessToken": "jwt-token",
+  "sessionId": "SES-4D5D8E7A3B1C",
+  "accessToken": "jwt",
+  "refreshToken": "opaque-refresh-token",
   "tokenType": "Bearer",
   "expiresInSeconds": 900,
+  "refreshExpiresInSeconds": 1209600,
   "user": {
     "userId": "uuid",
     "email": "user@example.com",
@@ -165,32 +268,52 @@ Header:
     "role": "CUSTOMER",
     "discountCategory": "NONE",
     "accountStatus": "ACTIVE",
-    "createdAt": "2026-04-09T13:00:00"
+    "createdAt": "2026-04-25T13:00:00"
   }
 }
 ```
 
-## 5. Hire Option APIs
-
-### 5.1 GET `/api/v1/hire-options`
-
-Returns active options sorted by duration.
-
-Response `data` item:
+`POST /api/v1/auth/refresh`
 
 ```json
 {
-  "hireOptionId": "HIRE-H1",
-  "code": "H1",
-  "durationMinutes": 60,
-  "basePrice": 3.0,
-  "active": true
+  "refreshToken": "opaque-refresh-token"
 }
 ```
 
-### 5.2 POST `/api/v1/pricing/quotes`
+`POST /api/v1/auth/password/forgot`
 
-Request:
+Current implementation is coursework-oriented:
+- it creates a reset token in `password_reset_tokens`
+- it returns the token in the response body instead of sending a real email
+
+`POST /api/v1/auth/password/reset`
+
+```json
+{
+  "resetToken": "token-from-forgot-password",
+  "newPassword": "NewPassw0rd!"
+}
+```
+
+### 4.2 Payment Method
+
+`POST /api/v1/payment-methods`
+
+```json
+{
+  "brand": "VISA",
+  "cardNumber": "4111111111111111",
+  "expiryMonth": 12,
+  "expiryYear": 2030,
+  "label": "Personal card",
+  "isDefault": true
+}
+```
+
+### 4.3 Pricing and Discounts
+
+`POST /api/v1/pricing/quotes`
 
 ```json
 {
@@ -199,516 +322,203 @@ Request:
 }
 ```
 
-Validation:
-- `hireOptionCode` required
-- `scooterId` optional (currently not used in pricing calculation)
-
-Response `data`:
-
-```json
-{
-  "basePrice": 12.0,
-  "appliedDiscounts": [],
-  "finalPrice": 12.0,
-  "currency": "GBP"
-}
-```
-
-### 5.3 GET `/api/v1/admin/hire-options`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
 Behavior:
-- Returns all hire options, including inactive ones
+- without bearer token: base price only
+- with bearer token: applies currently eligible discount rules
 
-Response `data` item:
-
-```json
-{
-  "hireOptionId": "HIRE-H1",
-  "code": "H1",
-  "durationMinutes": 60,
-  "basePrice": 3.0,
-  "active": true,
-  "createdAt": "2026-04-09T13:00:00",
-  "updatedAt": "2026-04-09T13:00:00"
-}
-```
-
-### 5.4 POST `/api/v1/admin/hire-options`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Request:
+`POST /api/v1/admin/discount-rules`
 
 ```json
 {
-  "code": "H2",
-  "durationMinutes": 120,
-  "basePrice": 6.0
-}
-```
-
-Behavior:
-- `code` is normalized to uppercase
-- `hireOptionId` is generated as `HIRE-{CODE}`
-- duplicate `code` or generated `hireOptionId` is rejected
-
-### 5.5 PATCH `/api/v1/admin/hire-options/{hireOptionId}`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Request:
-
-```json
-{
-  "durationMinutes": 180,
-  "basePrice": 8.5
-}
-```
-
-Behavior:
-- At least one field required
-- Only `durationMinutes` and `basePrice` are mutable
-
-### 5.6 DELETE `/api/v1/admin/hire-options/{hireOptionId}`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Behavior:
-- Soft disable only
-- Returns the disabled hire option payload with `active=false`
-
-## 6. Booking APIs (Create / Query / Modify / Cancel)
-
-### 6.1 POST `/api/v1/bookings`
-
-Header:
-- `Authorization: Bearer <access_token>`
-
-Request:
-
-```json
-{
-  "scooterId": "SCO-0001",
-  "hireOptionId": "HIRE-H1",
-  "plannedStartAt": "2026-04-09T13:30:00"
-}
-```
-
-Validation and behavior:
-- `scooterId` required
-- `hireOptionId` required
-- `hireOptionId` accepts either `hire_option_id` (e.g. `HIRE-H1`) or code (e.g. `H1`)
-- Scooter must be in `AVAILABLE` status
-- Scooter reservation update is conditional (`AVAILABLE` -> `RESERVED`) to reduce race conflicts
-- Created booking status is `CONFIRMED`
-- Created booking payment status is `UNPAID`
-
-Response `data`:
-
-```json
-{
-  "bookingId": "BKG-1234abcd",
-  "status": "CONFIRMED",
-  "scooterStatusSnapshot": "RESERVED",
-  "startAt": "2026-04-09T13:30:00",
-  "endAt": "2026-04-09T14:30:00",
-  "priceBreakdown": {
-    "base": 3.0,
-    "discount": 0.0,
-    "finalPrice": 3.0
-  }
-}
-```
-
-### 6.2 GET `/api/v1/bookings`
-
-Header:
-- `Authorization: Bearer <access_token>`
-
-Query params:
-- `status` optional, values: `CONFIRMED` / `CANCELLED`
-
-### 6.3 GET `/api/v1/bookings/{bookingId}`
-
-Header:
-- `Authorization: Bearer <access_token>`
-
-Behavior:
-- Only booking owner can query detail
-
-### 6.4 PATCH `/api/v1/bookings/{bookingId}`
-
-Header:
-- `Authorization: Bearer <access_token>`
-
-Request (at least one field required):
-
-```json
-{
-  "scooterId": "SCO-0002",
-  "hireOptionId": "H4",
-  "plannedStartAt": "2026-04-09T15:00:00"
-}
-```
-
-### 6.5 POST `/api/v1/bookings/{bookingId}/cancel`
-
-Header:
-- `Authorization: Bearer <access_token>`
-
-Request body is optional. If provided:
-
-```json
-{
-  "reason": "change of plan"
-}
-```
-
-## 7. Scooter Type APIs
-
-### 7.1 GET `/api/v1/scooter-types`
-
-Behavior:
-- Public endpoint
-- Returns active scooter types only
-
-Response `data`:
-
-```json
-[
-  {
-    "typeCode": "ANDROMEDA",
-    "displayName": "ANDROMEDA",
-    "imageUrl": "/images/scooter-types/andromeda.png",
-    "description": "High-performance urban scooter.",
-    "active": true
-  }
-]
-```
-
-### 7.2 GET `/api/v1/scooter-types/{typeCode}`
-
-Behavior:
-- Public endpoint
-- `typeCode` is case-insensitive and normalized to uppercase
-
-Response `data`:
-
-```json
-{
-  "typeCode": "GALAXY_SEAT",
-  "displayName": "GALAXY Seat",
-  "imageUrl": "/images/scooter-types/galaxy-seat.png",
-  "description": "Comfort-focused seated scooter.",
+  "type": "FREQUENT_USER",
+  "thresholdHoursPerWeek": 8.0,
+  "percentage": 15.0,
   "active": true
 }
 ```
 
-### 7.3 GET `/api/v1/admin/scooter-types`
+### 4.4 Booking
 
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Behavior:
-- Returns all scooter types, including inactive ones
-
-Response `data`:
-
-```json
-[
-  {
-    "typeCode": "ANDROMEDA",
-    "displayName": "ANDROMEDA",
-    "imageUrl": "/images/scooter-types/andromeda.png",
-    "description": "High-performance urban scooter.",
-    "active": true,
-    "createdAt": "2026-04-10T13:00:00",
-    "updatedAt": "2026-04-10T13:00:00"
-  }
-]
-```
-
-### 7.4 POST `/api/v1/admin/scooter-types`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Request:
-
-```json
-{
-  "typeCode": "SOLAR_X",
-  "displayName": "SOLAR X",
-  "imageUrl": "/images/scooter-types/solar-x.png",
-  "description": "Compact city scooter."
-}
-```
-
-Behavior:
-- `typeCode` is normalized to uppercase
-- duplicate `typeCode` is rejected
-- image file management is external to this endpoint; the API stores metadata only
-
-### 7.5 PATCH `/api/v1/admin/scooter-types/{typeCode}`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Request:
-
-```json
-{
-  "displayName": "GALAXY Seat Pro",
-  "imageUrl": "/images/scooter-types/galaxy-seat-pro.png",
-  "description": "Updated comfort-focused seated scooter."
-}
-```
-
-Behavior:
-- At least one field required
-- Mutable fields: `displayName`, `imageUrl`, `description`
-
-### 7.6 DELETE `/api/v1/admin/scooter-types/{typeCode}`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Behavior:
-- Soft disable only
-- Existing scooters retain their `typeCode`
-- Public `/scooter-types` no longer returns the disabled type
-
-## 8. Scooter Public APIs
-
-### 8.1 GET `/api/v1/scooters/ids`
-
-Query params:
-- `status` required, values:
-  - `AVAILABLE`
-  - `RESERVED`
-  - `IN_USE`
-  - `MAINTENANCE`
-  - `UNAVAILABLE`
-
-Response `data`:
-
-```json
-{
-  "status": "AVAILABLE",
-  "scooterIds": ["SCO-0001", "SCO-0002"]
-}
-```
-
-### 8.2 GET `/api/v1/scooters/map-points`
-
-Behavior:
-- Public endpoint
-- Returns scooters with non-null `lat` and `lng`
-- Ordered by `scooterId`
-
-Response `data`:
-
-```json
-[
-  {
-    "scooterId": "SCO-0001",
-    "typeCode": "ANDROMEDA",
-    "typeDisplayName": "ANDROMEDA",
-    "typeImageUrl": "/images/scooter-types/andromeda.png",
-    "status": "AVAILABLE",
-    "batteryPercent": 92,
-    "lat": 51.5074,
-    "lng": -0.1278,
-    "zone": "ZONE-A"
-  }
-]
-```
-
-## 9. Manager Scooter Management APIs
-
-### 9.1 GET `/api/v1/admin/scooters`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Query params:
-- `status` optional, values:
-  - `AVAILABLE`
-  - `RESERVED`
-  - `IN_USE`
-  - `MAINTENANCE`
-  - `UNAVAILABLE`
-
-Response `data` item:
+`POST /api/v1/bookings`
 
 ```json
 {
   "scooterId": "SCO-0001",
-  "typeCode": "ANDROMEDA",
-  "typeDisplayName": "ANDROMEDA",
-  "typeImageUrl": "/images/scooter-types/andromeda.png",
-  "status": "AVAILABLE",
-  "batteryPercent": 92,
-  "lat": 51.5074,
-  "lng": -0.1278,
-  "zone": "ZONE-A",
-  "version": 0,
-  "createdAt": "2026-04-09T13:00:00",
-  "updatedAt": "2026-04-09T13:00:00"
+  "hireOptionId": "HIRE-H4",
+  "plannedStartAt": "2026-04-25T14:00:00"
 }
 ```
 
-### 9.2 POST `/api/v1/admin/scooters`
+Current behavior:
+- booking is created as `PENDING_PAYMENT`
+- scooter is moved from `AVAILABLE` to `RESERVED`
+- booking price already includes eligible discounts
 
-Header:
-- `Authorization: Bearer <manager_access_token>`
+`PATCH /api/v1/bookings/{bookingId}`
 
-Request:
+Supported fields:
+- `scooterId`
+- `hireOptionId`
+- `plannedStartAt`
+
+Current behavior:
+- the booking is recalculated
+- payment state is reset to `UNPAID`
+- booking status is reset to `PENDING_PAYMENT`
+
+`POST /api/v1/bookings/{bookingId}/extend`
 
 ```json
 {
-  "scooterId": "SCO-0100",
-  "typeCode": "ANDROMEDA",
-  "status": "AVAILABLE",
-  "batteryPercent": 100,
-  "lat": 51.501,
-  "lng": -0.141,
-  "zone": "ZONE-D"
+  "additionalHireOptionCode": "H1"
 }
 ```
 
-Behavior:
-- `scooterId` is normalized to uppercase
-- `typeCode` must match an active scooter type
-- `status` defaults to `AVAILABLE` if omitted
-- `batteryPercent` defaults to `100` if omitted
-- `lat` and `lng` must be provided together
-
-### 9.3 PATCH `/api/v1/admin/scooters/{scooterId}`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Request:
+`POST /api/v1/staff/bookings/guest`
 
 ```json
 {
-  "typeCode": "ORION_ULTRA",
-  "batteryPercent": 84,
-  "lat": 51.502,
-  "lng": -0.142,
-  "zone": "ZONE-E"
+  "guestName": "Alex Guest",
+  "guestEmail": "guest@example.com",
+  "guestPhone": "10086",
+  "scooterId": "SCO-0002",
+  "hireOptionId": "HIRE-H1",
+  "plannedStartAt": "2026-04-25T16:00:00"
 }
 ```
 
-Behavior:
-- At least one field required
-- Mutable fields: `typeCode`, `batteryPercent`, `lat`, `lng`, `zone`
-- `typeCode`, if present, must match an active scooter type
-- `lat` and `lng` must remain a complete pair after update
-- Successful update increments scooter `version`
+`PATCH /api/v1/admin/bookings/{bookingId}/override`
 
-### 9.4 PATCH `/api/v1/admin/scooters/{scooterId}/status`
+Supported fields:
+- `status`
+- `paymentStatus`
+- `scooterId`
+- `cancelReason`
 
-Header:
-- `Authorization: Bearer <manager_access_token>`
+### 4.5 Payments
 
-Request:
+`POST /api/v1/bookings/{bookingId}/payments`
 
 ```json
 {
-  "status": "MAINTENANCE"
+  "method": "SAVED_CARD",
+  "paymentMethodId": "PM-1234567890",
+  "amount": 10.20,
+  "deferSettlement": false,
+  "simulatedOutcome": "SUCCESS"
 }
 ```
 
-Behavior:
-- Successful update increments scooter `version`
+Notes:
+- `method` supports `SAVED_CARD` and `ONE_TIME_CARD`
+- `deferSettlement=true` creates a payment in `INITIATED`
+- if settlement is not deferred, the current default path immediately simulates success/failure
+- a fully paid booking moves from `PENDING_PAYMENT` to `CONFIRMED`
+- confirmation and notification records are created when a booking becomes fully paid
 
-### 9.5 POST `/api/v1/admin/scooters/bulk-status`
-
-Header:
-- `Authorization: Bearer <manager_access_token>`
-
-Request:
+`POST /api/v1/payments/{paymentId}/refund`
 
 ```json
 {
-  "scooterIds": ["SCO-0001", "SCO-0002"],
-  "status": "MAINTENANCE"
+  "amount": 5.00
 }
 ```
 
-Behavior:
-- All scooter IDs must exist, otherwise request fails with `RESOURCE_NOT_FOUND`
-- Successful update increments each scooter `version`
+If `amount` is omitted, the implementation refunds the remaining refundable balance.
 
-Response `data`:
+### 4.6 Issues
+
+`POST /api/v1/issues`
 
 ```json
 {
-  "status": "MAINTENANCE",
-  "updatedCount": 2,
-  "scooterIds": ["SCO-0001", "SCO-0002"]
+  "bookingId": "BKG-12345678",
+  "scooterId": "SCO-0001",
+  "title": "Brake feels weak",
+  "description": "Braking distance increased during the ride",
+  "priority": "LOW"
 }
 ```
 
-## 10. State Transitions (Current Implementation)
+`POST /api/v1/issues/{issueId}/comments`
 
-### 10.1 Booking
+```json
+{
+  "message": "Additional detail or manager reply"
+}
+```
 
-| From | Endpoint | To |
-|---|---|---|
-| `CONFIRMED` | `PATCH /bookings/{bookingId}` | `CONFIRMED` |
-| `CONFIRMED` | `POST /bookings/{bookingId}/cancel` | `CANCELLED` |
+### 4.7 Analytics
 
-### 10.2 Scooter
+Supported query params:
+- `startDate=YYYY-MM-DD`
+- `endDate=YYYY-MM-DD`
 
-| From | Trigger | To |
-|---|---|---|
-| `AVAILABLE` | `POST /bookings` | `RESERVED` |
-| `RESERVED` | `PATCH /bookings/{bookingId}` with scooter changed | `AVAILABLE` |
-| `AVAILABLE` | `PATCH /bookings/{bookingId}` with scooter changed | `RESERVED` |
-| `RESERVED` | `POST /bookings/{bookingId}/cancel` | `AVAILABLE` |
-| any | `PATCH /admin/scooters/{scooterId}/status` | manager-selected status |
-| any | `POST /admin/scooters/bulk-status` | manager-selected status |
+Current implementation uses recorded `payments` rows as revenue source.
 
-## 11. Error Codes (Currently Used)
+## 5. State and Behavior Notes
 
-| Code | HTTP | Meaning |
-|---|---|---|
-| `VALIDATION_ERROR` | 400 | Request payload validation failed |
-| `AUTH_INVALID_CREDENTIALS` | 401 | Invalid login/token/user |
-| `AUTH_TOKEN_EXPIRED` | 401 | Access token expired |
-| `AUTH_FORBIDDEN` | 401/403 | Missing token or no permission |
-| `RESOURCE_NOT_FOUND` | 404 | User/scooter/hire option/booking/scooter type not found |
-| `SCOOTER_NOT_AVAILABLE` | 409 | Scooter is not available for booking/update |
-| `BOOKING_CONFLICT` | 409 | Booking state conflict during modify/cancel |
-| `INTERNAL_ERROR` | 500 | Unhandled server error |
+### 5.1 Booking
 
-## 12. Database (Current Implementation)
+Current implemented state flow:
+- `PENDING_PAYMENT` -> payment success -> `CONFIRMED`
+- `CONFIRMED` -> `/bookings/{id}/start` -> `ACTIVE`
+- `ACTIVE` -> `/bookings/{id}/end` -> `COMPLETED`
+- `PENDING_PAYMENT` or `CONFIRMED` -> `/bookings/{id}/cancel` -> `CANCELLED`
 
-Current tables used by the backend:
-- `users`
-- `hire_options`
-- `scooter_types`
-- `scooters`
-- `bookings`
+### 5.2 Scooter
 
-Current scooter type design:
-- `scooter_types.type_code` is the stable type identifier
-- `scooters.type_code` references `scooter_types.type_code`
-- images are stored as static files, while `scooter_types.image_url` stores the public path
-- manager scooter type APIs update metadata in `scooter_types`
+Current implemented transitions:
+- `AVAILABLE` -> booking created -> `RESERVED`
+- `RESERVED` -> booking start -> `IN_USE`
+- `IN_USE` -> booking end -> `AVAILABLE`
+- manager endpoints can directly set `AVAILABLE`, `RESERVED`, `IN_USE`, `MAINTENANCE`, `UNAVAILABLE`
 
-Current seeded scooter types:
-- `ANDROMEDA`
-- `GALAXY_SEAT`
-- `LUNAR_LITE`
-- `NEBULA_FAMILY`
-- `ORION_ULTRA`
+### 5.3 Issue
+
+Current implemented values:
+- priority: `LOW`, `HIGH`, `CRITICAL`
+- status: `OPEN`, `IN_REVIEW`, `RESOLVED`, `CLOSED`
+
+## 6. Security and Concurrency Notes
+
+Implemented security / reliability measures:
+- BCrypt password hashing
+- JWT access token + stored refresh session rotation
+- password reset tokens stored in database
+- manager audit logs in `audit_logs`
+- booking reservation uses conditional scooter status update
+- scooter admin updates increment `version`
+- payment, confirmation, notification, issue and booking event records are all persisted in MySQL
+
+This is how the current backend addresses ID 3 and ID 23.
+
+## 7. Backlog Coverage Matrix
+
+| ID | Coverage in Current Backend |
+|---|---|
+| 1 | `/auth/*`, `/users/me`, `/users/me/usage-summary` |
+| 2 | `/payment-methods/*` |
+| 3 | JWT + refresh sessions + password reset + admin status update + `/admin/audit-logs` |
+| 4 | `/hire-options`, `/pricing/quotes` |
+| 5 | `/bookings` |
+| 6 | `/bookings/{id}/payments`, `/payments/*` |
+| 7 | `/bookings/{id}/confirmation/resend`, `/notifications/*` |
+| 8 | `/bookings/{id}/confirmation`, `/confirmations`, `/bookings/{id}`, `/bookings/{id}/timeline` |
+| 9 | `/staff/bookings/guest*` |
+| 10 | booking lifecycle + `/admin/scooters/{id}/status` + `/admin/scooters/bulk-status` |
+| 11 | `/bookings/{id}/extend` |
+| 12 | `/bookings/{id}/cancel` |
+| 13 | `/issues*` |
+| 14 | `/admin/issues/*` |
+| 15 | `/admin/issues/high-priority` |
+| 16 | `/admin/hire-options/*`, `/admin/scooters/*`, `/admin/scooter-types/*` |
+| 17 | `/scooters`, `/scooters/{id}`, `/scooters/availability` |
+| 18 | `/scooters/map-points` |
+| 19 | `/admin/analytics/revenue/weekly-by-hire-option` |
+| 20 | `/admin/analytics/revenue/daily-combined` |
+| 21 | `/admin/analytics/revenue/weekly-chart` |
+| 22 | `/discounts/eligibility`, `/admin/discount-rules/*`, quote discount preview |
+| 23 | transactional reservation, scooter versioning, stored audit/event records |
+| 24 | frontend concern, no backend endpoint |
+| 25 | frontend concern, no backend endpoint |

--- a/urbanova/src/main/java/com/lcyhz/urbanova/common/exception/ErrorCodes.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/common/exception/ErrorCodes.java
@@ -11,6 +11,9 @@ public final class ErrorCodes {
     public static final String RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND";
     public static final String BOOKING_CONFLICT = "BOOKING_CONFLICT";
     public static final String SCOOTER_NOT_AVAILABLE = "SCOOTER_NOT_AVAILABLE";
+    public static final String PAYMENT_FAILED = "PAYMENT_FAILED";
+    public static final String IDEMPOTENCY_KEY_REUSED = "IDEMPOTENCY_KEY_REUSED";
+    public static final String PRECONDITION_FAILED = "PRECONDITION_FAILED";
     public static final String INTERNAL_ERROR = "INTERNAL_ERROR";
 }
 

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminAnalyticsController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminAnalyticsController.java
@@ -1,0 +1,58 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.AnalyticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/admin/analytics")
+@RequiredArgsConstructor
+public class AdminAnalyticsController {
+    private final AnalyticsService analyticsService;
+
+    @GetMapping("/revenue/estimate")
+    public ApiResponse<Map<String, Object>> revenueEstimate(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(analyticsService.revenueEstimate(startDate, endDate));
+    }
+
+    @GetMapping("/revenue/weekly-by-hire-option")
+    public ApiResponse<List<Map<String, Object>>> weeklyByHireOption(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(analyticsService.weeklyByHireOption(startDate));
+    }
+
+    @GetMapping("/revenue/daily-combined")
+    public ApiResponse<List<Map<String, Object>>> dailyCombined(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(analyticsService.dailyCombined(startDate));
+    }
+
+    @GetMapping("/revenue/weekly-chart")
+    public ApiResponse<Map<String, Object>> weeklyChart(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(analyticsService.weeklyChart(startDate));
+    }
+
+    @GetMapping("/usage/frequent-users")
+    public ApiResponse<List<Map<String, Object>>> frequentUsers() {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(analyticsService.frequentUsers());
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminBookingController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminBookingController.java
@@ -1,0 +1,45 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.BookingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/admin/bookings")
+@RequiredArgsConstructor
+public class AdminBookingController {
+    private final BookingService bookingService;
+
+    @GetMapping
+    public ApiResponse<List<Map<String, Object>>> listBookings(@RequestParam(required = false) String status,
+                                                               @RequestParam(required = false) String paymentStatus,
+                                                               @RequestParam(required = false) String customerType) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(bookingService.listAdminBookings(status, paymentStatus, customerType));
+    }
+
+    @GetMapping("/{bookingId}")
+    public ApiResponse<Map<String, Object>> getBooking(@PathVariable String bookingId) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(bookingService.getAdminBookingDetail(bookingId));
+    }
+
+    @PatchMapping("/{bookingId}/override")
+    public ApiResponse<Map<String, Object>> overrideBooking(@PathVariable String bookingId,
+                                                            @RequestBody Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(bookingService.overrideBooking(bookingId, request));
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminHireOptionController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminHireOptionController.java
@@ -6,6 +6,7 @@ import com.lcyhz.urbanova.dto.admin.hire.CreateHireOptionRequest;
 import com.lcyhz.urbanova.dto.admin.hire.UpdateHireOptionRequest;
 import com.lcyhz.urbanova.security.AuthContext;
 import com.lcyhz.urbanova.service.HireOptionService;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
 import com.lcyhz.urbanova.vo.hire.AdminHireOptionVo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminHireOptionController {
     private final HireOptionService hireOptionService;
+    private final PlatformSupportService platformSupportService;
 
     @GetMapping
     public ApiResponse<List<AdminHireOptionVo>> listHireOptions() {
@@ -35,19 +37,25 @@ public class AdminHireOptionController {
     @PostMapping
     public ApiResponse<AdminHireOptionVo> createHireOption(@Valid @RequestBody CreateHireOptionRequest request) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(hireOptionService.createHireOption(request));
+        AdminHireOptionVo result = hireOptionService.createHireOption(request);
+        platformSupportService.recordAudit("HIRE_OPTION_CREATED", "HIRE_OPTION", result.getHireOptionId(), result.getCode());
+        return ApiResponse.success(result);
     }
 
     @PatchMapping("/{hireOptionId}")
     public ApiResponse<AdminHireOptionVo> updateHireOption(@PathVariable String hireOptionId,
                                                            @Valid @RequestBody UpdateHireOptionRequest request) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(hireOptionService.updateHireOption(hireOptionId, request));
+        AdminHireOptionVo result = hireOptionService.updateHireOption(hireOptionId, request);
+        platformSupportService.recordAudit("HIRE_OPTION_UPDATED", "HIRE_OPTION", result.getHireOptionId(), result.getCode());
+        return ApiResponse.success(result);
     }
 
     @DeleteMapping("/{hireOptionId}")
     public ApiResponse<AdminHireOptionVo> disableHireOption(@PathVariable String hireOptionId) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(hireOptionService.disableHireOption(hireOptionId));
+        AdminHireOptionVo result = hireOptionService.disableHireOption(hireOptionId);
+        platformSupportService.recordAudit("HIRE_OPTION_DISABLED", "HIRE_OPTION", result.getHireOptionId(), result.getCode());
+        return ApiResponse.success(result);
     }
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminScooterController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminScooterController.java
@@ -8,6 +8,7 @@ import com.lcyhz.urbanova.dto.admin.scooter.UpdateScooterRequest;
 import com.lcyhz.urbanova.dto.admin.scooter.UpdateScooterStatusRequest;
 import com.lcyhz.urbanova.security.AuthContext;
 import com.lcyhz.urbanova.service.ScooterService;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
 import com.lcyhz.urbanova.vo.scooter.AdminScooterVo;
 import com.lcyhz.urbanova.vo.scooter.BulkScooterStatusUpdateVo;
 import jakarta.validation.Valid;
@@ -28,6 +29,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminScooterController {
     private final ScooterService scooterService;
+    private final PlatformSupportService platformSupportService;
 
     @GetMapping
     public ApiResponse<List<AdminScooterVo>> listScooters(@RequestParam(required = false) String status) {
@@ -38,27 +40,35 @@ public class AdminScooterController {
     @PostMapping
     public ApiResponse<AdminScooterVo> createScooter(@Valid @RequestBody CreateScooterRequest request) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(scooterService.createScooter(request));
+        AdminScooterVo result = scooterService.createScooter(request);
+        platformSupportService.recordAudit("SCOOTER_CREATED", "SCOOTER", result.getScooterId(), result.getStatus());
+        return ApiResponse.success(result);
     }
 
     @PatchMapping("/{scooterId}")
     public ApiResponse<AdminScooterVo> updateScooter(@PathVariable String scooterId,
                                                      @Valid @RequestBody UpdateScooterRequest request) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(scooterService.updateScooter(scooterId, request));
+        AdminScooterVo result = scooterService.updateScooter(scooterId, request);
+        platformSupportService.recordAudit("SCOOTER_UPDATED", "SCOOTER", result.getScooterId(), result.getStatus());
+        return ApiResponse.success(result);
     }
 
     @PatchMapping("/{scooterId}/status")
     public ApiResponse<AdminScooterVo> updateScooterStatus(@PathVariable String scooterId,
                                                            @Valid @RequestBody UpdateScooterStatusRequest request) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(scooterService.updateScooterStatus(scooterId, request));
+        AdminScooterVo result = scooterService.updateScooterStatus(scooterId, request);
+        platformSupportService.recordAudit("SCOOTER_STATUS_UPDATED", "SCOOTER", result.getScooterId(), result.getStatus());
+        return ApiResponse.success(result);
     }
 
     @PostMapping("/bulk-status")
     public ApiResponse<BulkScooterStatusUpdateVo> bulkUpdateScooterStatus(
             @Valid @RequestBody BulkUpdateScooterStatusRequest request) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(scooterService.bulkUpdateScooterStatus(request));
+        BulkScooterStatusUpdateVo result = scooterService.bulkUpdateScooterStatus(request);
+        platformSupportService.recordAudit("SCOOTER_BULK_STATUS_UPDATED", "SCOOTER", String.join(",", result.getScooterIds()), result.getStatus());
+        return ApiResponse.success(result);
     }
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminScooterTypeController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminScooterTypeController.java
@@ -6,6 +6,7 @@ import com.lcyhz.urbanova.dto.admin.scootertype.CreateScooterTypeRequest;
 import com.lcyhz.urbanova.dto.admin.scootertype.UpdateScooterTypeRequest;
 import com.lcyhz.urbanova.security.AuthContext;
 import com.lcyhz.urbanova.service.ScooterTypeService;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
 import com.lcyhz.urbanova.vo.scooter.AdminScooterTypeVo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminScooterTypeController {
     private final ScooterTypeService scooterTypeService;
+    private final PlatformSupportService platformSupportService;
 
     @GetMapping
     public ApiResponse<List<AdminScooterTypeVo>> listScooterTypes() {
@@ -35,19 +37,25 @@ public class AdminScooterTypeController {
     @PostMapping
     public ApiResponse<AdminScooterTypeVo> createScooterType(@Valid @RequestBody CreateScooterTypeRequest request) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(scooterTypeService.createScooterType(request));
+        AdminScooterTypeVo result = scooterTypeService.createScooterType(request);
+        platformSupportService.recordAudit("SCOOTER_TYPE_CREATED", "SCOOTER_TYPE", result.getTypeCode(), result.getDisplayName());
+        return ApiResponse.success(result);
     }
 
     @PatchMapping("/{typeCode}")
     public ApiResponse<AdminScooterTypeVo> updateScooterType(@PathVariable String typeCode,
                                                              @Valid @RequestBody UpdateScooterTypeRequest request) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(scooterTypeService.updateScooterType(typeCode, request));
+        AdminScooterTypeVo result = scooterTypeService.updateScooterType(typeCode, request);
+        platformSupportService.recordAudit("SCOOTER_TYPE_UPDATED", "SCOOTER_TYPE", result.getTypeCode(), result.getDisplayName());
+        return ApiResponse.success(result);
     }
 
     @DeleteMapping("/{typeCode}")
     public ApiResponse<AdminScooterTypeVo> disableScooterType(@PathVariable String typeCode) {
         AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
-        return ApiResponse.success(scooterTypeService.disableScooterType(typeCode));
+        AdminScooterTypeVo result = scooterTypeService.disableScooterType(typeCode);
+        platformSupportService.recordAudit("SCOOTER_TYPE_DISABLED", "SCOOTER_TYPE", result.getTypeCode(), result.getDisplayName());
+        return ApiResponse.success(result);
     }
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminUserController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/AdminUserController.java
@@ -1,0 +1,57 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.UserManagementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminUserController {
+    private final UserManagementService userManagementService;
+
+    @GetMapping("/users")
+    public ApiResponse<List<Map<String, Object>>> listUsers(@RequestParam(required = false) String role,
+                                                            @RequestParam(required = false) String accountStatus) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(userManagementService.listUsers(role, accountStatus));
+    }
+
+    @GetMapping("/users/{userId}")
+    public ApiResponse<Map<String, Object>> getUser(@PathVariable String userId) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(userManagementService.getUserDetail(userId));
+    }
+
+    @PatchMapping("/users/{userId}/status")
+    public ApiResponse<Map<String, Object>> updateStatus(@PathVariable String userId,
+                                                         @RequestBody Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(userManagementService.updateUserStatus(userId, request == null ? null : String.valueOf(request.get("accountStatus"))));
+    }
+
+    @GetMapping("/users/{userId}/bookings")
+    public ApiResponse<List<Map<String, Object>>> listUserBookings(@PathVariable String userId) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(userManagementService.listUserBookings(userId));
+    }
+
+    @GetMapping("/audit-logs")
+    public ApiResponse<List<Map<String, Object>>> listAuditLogs(@RequestParam(required = false) String action,
+                                                                @RequestParam(required = false) Integer limit) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(userManagementService.listAuditLogs(action, limit));
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/AuthController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/AuthController.java
@@ -5,21 +5,26 @@ import com.lcyhz.urbanova.dto.auth.LoginRequest;
 import com.lcyhz.urbanova.dto.auth.RegisterRequest;
 import com.lcyhz.urbanova.security.AuthContext;
 import com.lcyhz.urbanova.service.AuthService;
+import com.lcyhz.urbanova.service.UserManagementService;
 import com.lcyhz.urbanova.vo.auth.AuthPayload;
 import com.lcyhz.urbanova.vo.auth.UserProfileVo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final UserManagementService userManagementService;
 
     @PostMapping("/auth/register")
     public ApiResponse<AuthPayload> register(@Valid @RequestBody RegisterRequest request) {
@@ -31,9 +36,42 @@ public class AuthController {
         return ApiResponse.success(authService.login(request));
     }
 
+    @PostMapping("/auth/refresh")
+    public ApiResponse<AuthPayload> refresh(@RequestBody Map<String, Object> request) {
+        return ApiResponse.success(authService.refresh(request == null ? null : (String) request.get("refreshToken")));
+    }
+
+    @PostMapping("/auth/logout")
+    public ApiResponse<Map<String, Object>> logout(@RequestBody(required = false) Map<String, Object> request) {
+        String refreshToken = request == null ? null : (String) request.get("refreshToken");
+        return ApiResponse.success(authService.logout(AuthContext.getRequiredUserId(), refreshToken));
+    }
+
+    @PostMapping("/auth/password/forgot")
+    public ApiResponse<Map<String, Object>> forgotPassword(@RequestBody Map<String, Object> request) {
+        return ApiResponse.success(authService.forgotPassword(request == null ? null : (String) request.get("email")));
+    }
+
+    @PostMapping("/auth/password/reset")
+    public ApiResponse<Map<String, Object>> resetPassword(@RequestBody Map<String, Object> request) {
+        return ApiResponse.success(authService.resetPassword(
+                request == null ? null : (String) request.get("resetToken"),
+                request == null ? null : (String) request.get("newPassword")));
+    }
+
     @GetMapping("/users/me")
     public ApiResponse<UserProfileVo> me() {
         return ApiResponse.success(authService.getCurrentUser(AuthContext.getRequiredUserId()));
+    }
+
+    @PatchMapping("/users/me")
+    public ApiResponse<Map<String, Object>> updateMe(@RequestBody Map<String, Object> request) {
+        return ApiResponse.success(userManagementService.updateCurrentUser(AuthContext.getRequiredUserId(), request));
+    }
+
+    @GetMapping("/users/me/usage-summary")
+    public ApiResponse<Map<String, Object>> usageSummary() {
+        return ApiResponse.success(userManagementService.getUsageSummary(AuthContext.getRequiredUserId()));
     }
 }
 

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/BookingController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/BookingController.java
@@ -1,14 +1,14 @@
 package com.lcyhz.urbanova.controller;
 
 import com.lcyhz.urbanova.common.api.ApiResponse;
-import com.lcyhz.urbanova.dto.booking.UpdateBookingRequest;
 import com.lcyhz.urbanova.dto.booking.CancelBookingRequest;
 import com.lcyhz.urbanova.dto.booking.CreateBookingRequest;
+import com.lcyhz.urbanova.dto.booking.UpdateBookingRequest;
 import com.lcyhz.urbanova.security.AuthContext;
 import com.lcyhz.urbanova.service.BookingService;
-import com.lcyhz.urbanova.vo.booking.CancelBookingVo;
 import com.lcyhz.urbanova.vo.booking.BookingDetailVo;
 import com.lcyhz.urbanova.vo.booking.BookingListItemVo;
+import com.lcyhz.urbanova.vo.booking.CancelBookingVo;
 import com.lcyhz.urbanova.vo.booking.CreateBookingVo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -60,5 +61,39 @@ public class BookingController {
         String userId = AuthContext.getRequiredUserId();
         CancelBookingRequest actualRequest = request == null ? new CancelBookingRequest() : request;
         return ApiResponse.success(bookingService.cancelBooking(userId, bookingId, actualRequest));
+    }
+
+    @PostMapping("/bookings/{bookingId}/start")
+    public ApiResponse<Map<String, Object>> startBooking(@PathVariable String bookingId) {
+        return ApiResponse.success(bookingService.startBooking(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                bookingId));
+    }
+
+    @PostMapping("/bookings/{bookingId}/end")
+    public ApiResponse<Map<String, Object>> endBooking(@PathVariable String bookingId) {
+        return ApiResponse.success(bookingService.endBooking(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                bookingId));
+    }
+
+    @PostMapping("/bookings/{bookingId}/extend")
+    public ApiResponse<Map<String, Object>> extendBooking(@PathVariable String bookingId,
+                                                          @RequestBody(required = false) Map<String, Object> request) {
+        return ApiResponse.success(bookingService.extendBooking(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                bookingId,
+                request));
+    }
+
+    @GetMapping("/bookings/{bookingId}/timeline")
+    public ApiResponse<List<Map<String, Object>>> getBookingTimeline(@PathVariable String bookingId) {
+        return ApiResponse.success(bookingService.getBookingTimeline(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                bookingId));
     }
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/ConfirmationController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/ConfirmationController.java
@@ -1,0 +1,43 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.BookingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ConfirmationController {
+    private final BookingService bookingService;
+
+    @GetMapping("/bookings/{bookingId}/confirmation")
+    public ApiResponse<Map<String, Object>> getBookingConfirmation(@PathVariable String bookingId) {
+        return ApiResponse.success(bookingService.getBookingConfirmation(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                bookingId));
+    }
+
+    @PostMapping("/bookings/{bookingId}/confirmation/resend")
+    public ApiResponse<Map<String, Object>> resendBookingConfirmation(@PathVariable String bookingId) {
+        return ApiResponse.success(bookingService.resendBookingConfirmation(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                bookingId));
+    }
+
+    @GetMapping("/confirmations")
+    public ApiResponse<List<Map<String, Object>>> listConfirmations() {
+        return ApiResponse.success(bookingService.listConfirmations(AuthContext.getRequiredUserId()));
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/DiscountController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/DiscountController.java
@@ -1,0 +1,54 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.DiscountRuleService;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class DiscountController {
+    private final DiscountRuleService discountRuleService;
+    private final PlatformSupportService platformSupportService;
+
+    @GetMapping("/discounts/eligibility")
+    public ApiResponse<Map<String, Object>> getEligibility() {
+        return ApiResponse.success(discountRuleService.getEligibility(AuthContext.getRequiredUserId()));
+    }
+
+    @GetMapping("/admin/discount-rules")
+    public ApiResponse<List<Map<String, Object>>> listRules() {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(discountRuleService.listRules());
+    }
+
+    @PostMapping("/admin/discount-rules")
+    public ApiResponse<Map<String, Object>> createRule(@RequestBody Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        Map<String, Object> result = discountRuleService.createRule(request);
+        platformSupportService.recordAudit("DISCOUNT_RULE_CREATED", "DISCOUNT_RULE", String.valueOf(result.get("discountRuleId")), String.valueOf(result.get("type")));
+        return ApiResponse.success(result);
+    }
+
+    @PatchMapping("/admin/discount-rules/{discountRuleId}")
+    public ApiResponse<Map<String, Object>> updateRule(@PathVariable String discountRuleId,
+                                                       @RequestBody Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        Map<String, Object> result = discountRuleService.updateRule(discountRuleId, request);
+        platformSupportService.recordAudit("DISCOUNT_RULE_UPDATED", "DISCOUNT_RULE", String.valueOf(result.get("discountRuleId")), String.valueOf(result.get("type")));
+        return ApiResponse.success(result);
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/HireOptionController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/HireOptionController.java
@@ -2,14 +2,17 @@ package com.lcyhz.urbanova.controller;
 
 import com.lcyhz.urbanova.common.api.ApiResponse;
 import com.lcyhz.urbanova.dto.pricing.PriceQuoteRequest;
+import com.lcyhz.urbanova.security.JwtService;
 import com.lcyhz.urbanova.service.HireOptionService;
 import com.lcyhz.urbanova.vo.hire.HireOptionVo;
 import com.lcyhz.urbanova.vo.pricing.PriceQuoteVo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HireOptionController {
     private final HireOptionService hireOptionService;
+    private final JwtService jwtService;
 
     @GetMapping("/hire-options")
     public ApiResponse<List<HireOptionVo>> listHireOptions() {
@@ -27,8 +31,13 @@ public class HireOptionController {
     }
 
     @PostMapping("/pricing/quotes")
-    public ApiResponse<PriceQuoteVo> quote(@Valid @RequestBody PriceQuoteRequest request) {
-        return ApiResponse.success(hireOptionService.quotePrice(request));
+    public ApiResponse<PriceQuoteVo> quote(@Valid @RequestBody PriceQuoteRequest request,
+                                           @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization) {
+        String userId = null;
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            userId = jwtService.parseToken(authorization.substring("Bearer ".length()).trim()).getUserId();
+        }
+        return ApiResponse.success(hireOptionService.quotePrice(userId, request));
     }
 }
 

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/IssueController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/IssueController.java
@@ -1,0 +1,87 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.IssueManagementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class IssueController {
+    private final IssueManagementService issueManagementService;
+
+    @PostMapping("/issues")
+    public ApiResponse<Map<String, Object>> createIssue(@RequestBody Map<String, Object> request) {
+        return ApiResponse.success(issueManagementService.createIssue(AuthContext.getRequiredUserId(), request));
+    }
+
+    @GetMapping("/issues")
+    public ApiResponse<List<Map<String, Object>>> listIssues(@RequestParam(required = false) String status) {
+        return ApiResponse.success(issueManagementService.listOwnIssues(AuthContext.getRequiredUserId(), status));
+    }
+
+    @GetMapping("/issues/{issueId}")
+    public ApiResponse<Map<String, Object>> getIssue(@PathVariable String issueId) {
+        return ApiResponse.success(issueManagementService.getIssue(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                issueId));
+    }
+
+    @PostMapping("/issues/{issueId}/comments")
+    public ApiResponse<Map<String, Object>> addComment(@PathVariable String issueId,
+                                                       @RequestBody Map<String, Object> request) {
+        return ApiResponse.success(issueManagementService.addComment(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                issueId,
+                request == null ? null : String.valueOf(request.get("message"))));
+    }
+
+    @GetMapping("/admin/issues")
+    public ApiResponse<List<Map<String, Object>>> listAdminIssues(@RequestParam(required = false) String status,
+                                                                  @RequestParam(required = false) String priority) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(issueManagementService.listAdminIssues(status, priority));
+    }
+
+    @PatchMapping("/admin/issues/{issueId}/priority")
+    public ApiResponse<Map<String, Object>> updatePriority(@PathVariable String issueId,
+                                                           @RequestBody Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(issueManagementService.updatePriority(issueId, request == null ? null : String.valueOf(request.get("priority"))));
+    }
+
+    @PatchMapping("/admin/issues/{issueId}/status")
+    public ApiResponse<Map<String, Object>> updateStatus(@PathVariable String issueId,
+                                                         @RequestBody Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(issueManagementService.updateStatus(issueId, request == null ? null : String.valueOf(request.get("status"))));
+    }
+
+    @PostMapping("/admin/issues/{issueId}/resolve")
+    public ApiResponse<Map<String, Object>> resolveIssue(@PathVariable String issueId,
+                                                         @RequestBody(required = false) Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(issueManagementService.resolve(issueId, request == null ? null : String.valueOf(request.get("feedback"))));
+    }
+
+    @GetMapping("/admin/issues/high-priority")
+    public ApiResponse<List<Map<String, Object>>> listHighPriorityIssues() {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(issueManagementService.listHighPriorityIssues());
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/MetaController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/MetaController.java
@@ -1,0 +1,26 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+public class MetaController {
+    @Value("${spring.application.name:urbanova}")
+    private String applicationName;
+
+    @GetMapping("/meta")
+    public ApiResponse<Map<String, Object>> meta() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("application", applicationName);
+        data.put("apiVersion", "v1");
+        data.put("buildMode", "dev");
+        return ApiResponse.success(data);
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/NotificationController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/NotificationController.java
@@ -1,0 +1,31 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ApiResponse<List<Map<String, Object>>> listNotifications() {
+        return ApiResponse.success(notificationService.listNotifications(AuthContext.getRequiredUserId()));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ApiResponse<Map<String, Object>> markRead(@PathVariable String notificationId) {
+        return ApiResponse.success(notificationService.markRead(AuthContext.getRequiredUserId(), notificationId));
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/PaymentController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/PaymentController.java
@@ -1,0 +1,67 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final PaymentService paymentService;
+
+    @PostMapping("/bookings/{bookingId}/payments")
+    public ApiResponse<Map<String, Object>> createPayment(@PathVariable String bookingId,
+                                                          @RequestBody(required = false) Map<String, Object> request) {
+        return ApiResponse.success(paymentService.createPayment(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                bookingId,
+                request));
+    }
+
+    @GetMapping("/bookings/{bookingId}/payments")
+    public ApiResponse<List<Map<String, Object>>> listBookingPayments(@PathVariable String bookingId) {
+        return ApiResponse.success(paymentService.listBookingPayments(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                bookingId));
+    }
+
+    @GetMapping("/payments/{paymentId}")
+    public ApiResponse<Map<String, Object>> getPaymentDetail(@PathVariable String paymentId) {
+        return ApiResponse.success(paymentService.getPaymentDetail(
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole(),
+                paymentId));
+    }
+
+    @PostMapping("/payments/{paymentId}/simulate-settlement")
+    public ApiResponse<Map<String, Object>> simulateSettlement(@PathVariable String paymentId,
+                                                               @RequestBody(required = false) Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(paymentService.simulateSettlement(
+                paymentId,
+                request == null ? null : String.valueOf(request.get("simulatedOutcome")),
+                AuthContext.getRequiredUserId(),
+                AuthContext.getRequiredUser().getRole()));
+    }
+
+    @PostMapping("/payments/{paymentId}/refund")
+    public ApiResponse<Map<String, Object>> refundPayment(@PathVariable String paymentId,
+                                                          @RequestBody(required = false) Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(paymentService.refundPayment(paymentId, request));
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/PaymentMethodController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/PaymentMethodController.java
@@ -1,0 +1,50 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.PaymentMethodService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/payment-methods")
+@RequiredArgsConstructor
+public class PaymentMethodController {
+    private final PaymentMethodService paymentMethodService;
+
+    @GetMapping
+    public ApiResponse<List<Map<String, Object>>> listPaymentMethods() {
+        return ApiResponse.success(paymentMethodService.listPaymentMethods(AuthContext.getRequiredUserId()));
+    }
+
+    @PostMapping
+    public ApiResponse<Map<String, Object>> createPaymentMethod(@RequestBody Map<String, Object> request) {
+        return ApiResponse.success(paymentMethodService.createPaymentMethod(AuthContext.getRequiredUserId(), request));
+    }
+
+    @PatchMapping("/{paymentMethodId}")
+    public ApiResponse<Map<String, Object>> updatePaymentMethod(@PathVariable String paymentMethodId,
+                                                                @RequestBody Map<String, Object> request) {
+        return ApiResponse.success(paymentMethodService.updatePaymentMethod(AuthContext.getRequiredUserId(), paymentMethodId, request));
+    }
+
+    @DeleteMapping("/{paymentMethodId}")
+    public ApiResponse<Map<String, Object>> deletePaymentMethod(@PathVariable String paymentMethodId) {
+        return ApiResponse.success(paymentMethodService.deletePaymentMethod(AuthContext.getRequiredUserId(), paymentMethodId));
+    }
+
+    @PostMapping("/{paymentMethodId}/default")
+    public ApiResponse<Map<String, Object>> setDefault(@PathVariable String paymentMethodId) {
+        return ApiResponse.success(paymentMethodService.setDefault(AuthContext.getRequiredUserId(), paymentMethodId));
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/ScooterController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/ScooterController.java
@@ -6,17 +6,31 @@ import com.lcyhz.urbanova.vo.scooter.ScooterMapPointVo;
 import com.lcyhz.urbanova.vo.scooter.ScooterIdsByStatusVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class ScooterController {
     private final ScooterService scooterService;
+
+    @GetMapping("/scooters")
+    public ApiResponse<List<Map<String, Object>>> listScooters(@RequestParam(required = false) String status,
+                                                               @RequestParam(required = false) String typeCode,
+                                                               @RequestParam(required = false) String zone) {
+        return ApiResponse.success(scooterService.listPublicScooters(status, typeCode, zone));
+    }
+
+    @GetMapping("/scooters/availability")
+    public ApiResponse<Map<String, Object>> getAvailabilitySummary() {
+        return ApiResponse.success(scooterService.getAvailabilitySummary());
+    }
 
     @GetMapping("/scooters/ids")
     public ApiResponse<ScooterIdsByStatusVo> queryScooterIdsByStatus(@RequestParam String status) {
@@ -26,5 +40,10 @@ public class ScooterController {
     @GetMapping("/scooters/map-points")
     public ApiResponse<List<ScooterMapPointVo>> listScooterMapPoints() {
         return ApiResponse.success(scooterService.listMapPoints());
+    }
+
+    @GetMapping("/scooters/{scooterId}")
+    public ApiResponse<Map<String, Object>> getScooterDetail(@PathVariable String scooterId) {
+        return ApiResponse.success(scooterService.getScooterDetail(scooterId));
     }
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/controller/StaffBookingController.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/controller/StaffBookingController.java
@@ -1,0 +1,34 @@
+package com.lcyhz.urbanova.controller;
+
+import com.lcyhz.urbanova.common.api.ApiResponse;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.service.BookingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/staff/bookings")
+@RequiredArgsConstructor
+public class StaffBookingController {
+    private final BookingService bookingService;
+
+    @PostMapping("/guest")
+    public ApiResponse<Map<String, Object>> createGuestBooking(@RequestBody Map<String, Object> request) {
+        AuthContext.requireRole(DomainConstants.ROLE_STAFF);
+        return ApiResponse.success(bookingService.createGuestBooking(AuthContext.getRequiredUserId(), request));
+    }
+
+    @GetMapping("/guest/{bookingId}")
+    public ApiResponse<Map<String, Object>> getGuestBooking(@PathVariable String bookingId) {
+        AuthContext.requireAnyRole(DomainConstants.ROLE_STAFF, DomainConstants.ROLE_MANAGER);
+        return ApiResponse.success(bookingService.getGuestBookingDetail(AuthContext.getRequiredUserId(), bookingId));
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/domain/DomainConstants.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/domain/DomainConstants.java
@@ -5,12 +5,39 @@ public final class DomainConstants {
     }
 
     public static final String ROLE_CUSTOMER = "CUSTOMER";
+    public static final String ROLE_STAFF = "STAFF";
     public static final String ROLE_MANAGER = "MANAGER";
+    public static final String ROLE_SYSTEM = "SYSTEM";
     public static final String ACCOUNT_ACTIVE = "ACTIVE";
+    public static final String ACCOUNT_SUSPENDED = "SUSPENDED";
+    public static final String ACCOUNT_DELETED = "DELETED";
     public static final String DISCOUNT_NONE = "NONE";
+    public static final String DISCOUNT_STUDENT = "STUDENT";
+    public static final String DISCOUNT_SENIOR = "SENIOR";
     public static final String CUSTOMER_TYPE_REGISTERED = "REGISTERED";
+    public static final String CUSTOMER_TYPE_GUEST = "GUEST";
     public static final String PAYMENT_STATUS_UNPAID = "UNPAID";
+    public static final String PAYMENT_STATUS_PAID = "PAID";
+    public static final String PAYMENT_STATUS_PARTIAL = "PARTIAL";
+    public static final String PAYMENT_STATUS_REFUNDED = "REFUNDED";
     public static final String CURRENCY_GBP = "GBP";
+
+    public static final class PaymentMethodStatus {
+        private PaymentMethodStatus() {
+        }
+
+        public static final String ACTIVE = "ACTIVE";
+        public static final String EXPIRED = "EXPIRED";
+        public static final String REMOVED = "REMOVED";
+    }
+
+    public static final class PaymentMethodType {
+        private PaymentMethodType() {
+        }
+
+        public static final String SAVED_CARD = "SAVED_CARD";
+        public static final String ONE_TIME_CARD = "ONE_TIME_CARD";
+    }
 
     public static final class ScooterStatus {
         private ScooterStatus() {
@@ -27,7 +54,75 @@ public final class DomainConstants {
         private BookingStatus() {
         }
 
+        public static final String PENDING_PAYMENT = "PENDING_PAYMENT";
         public static final String CONFIRMED = "CONFIRMED";
+        public static final String ACTIVE = "ACTIVE";
+        public static final String COMPLETED = "COMPLETED";
         public static final String CANCELLED = "CANCELLED";
+        public static final String EXPIRED = "EXPIRED";
+    }
+
+    public static final class PaymentStatus {
+        private PaymentStatus() {
+        }
+
+        public static final String INITIATED = "INITIATED";
+        public static final String SUCCEEDED = "SUCCEEDED";
+        public static final String FAILED = "FAILED";
+        public static final String REFUNDED = "REFUNDED";
+    }
+
+    public static final class PaymentOutcome {
+        private PaymentOutcome() {
+        }
+
+        public static final String SUCCESS = "SUCCESS";
+        public static final String FAILURE = "FAILURE";
+    }
+
+    public static final class NotificationType {
+        private NotificationType() {
+        }
+
+        public static final String BOOKING_CONFIRMATION = "BOOKING_CONFIRMATION";
+        public static final String BOOKING_CANCELLED = "BOOKING_CANCELLED";
+        public static final String PAYMENT_UPDATED = "PAYMENT_UPDATED";
+        public static final String ISSUE_UPDATED = "ISSUE_UPDATED";
+    }
+
+    public static final class ConfirmationStatus {
+        private ConfirmationStatus() {
+        }
+
+        public static final String SENT = "SENT";
+        public static final String RESENT = "RESENT";
+    }
+
+    public static final class IssuePriority {
+        private IssuePriority() {
+        }
+
+        public static final String LOW = "LOW";
+        public static final String HIGH = "HIGH";
+        public static final String CRITICAL = "CRITICAL";
+    }
+
+    public static final class IssueStatus {
+        private IssueStatus() {
+        }
+
+        public static final String OPEN = "OPEN";
+        public static final String IN_REVIEW = "IN_REVIEW";
+        public static final String RESOLVED = "RESOLVED";
+        public static final String CLOSED = "CLOSED";
+    }
+
+    public static final class DiscountRuleType {
+        private DiscountRuleType() {
+        }
+
+        public static final String FREQUENT_USER = "FREQUENT_USER";
+        public static final String STUDENT = "STUDENT";
+        public static final String SENIOR = "SENIOR";
     }
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/AuditLogEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/AuditLogEntity.java
@@ -1,0 +1,23 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("audit_logs")
+public class AuditLogEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String auditLogId;
+    private String actorUserId;
+    private String actorRole;
+    private String action;
+    private String targetType;
+    private String targetId;
+    private String details;
+    private LocalDateTime createdAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/AuthSessionEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/AuthSessionEntity.java
@@ -1,0 +1,22 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("auth_sessions")
+public class AuthSessionEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String sessionId;
+    private String userId;
+    private String refreshToken;
+    private LocalDateTime expiresAt;
+    private Integer revoked;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/BookingConfirmationEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/BookingConfirmationEntity.java
@@ -1,0 +1,25 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("booking_confirmations")
+public class BookingConfirmationEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String confirmationId;
+    private String bookingId;
+    private String userId;
+    private String recipientEmail;
+    private String channel;
+    private String status;
+    private String message;
+    private Integer resendCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/BookingEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/BookingEntity.java
@@ -17,10 +17,15 @@ public class BookingEntity {
     private String bookingRef;
     private String customerType;
     private String userId;
+    private String guestName;
+    private String guestEmail;
+    private String guestPhone;
     private String scooterId;
     private String hireOptionId;
     private LocalDateTime startAt;
     private LocalDateTime endAt;
+    private LocalDateTime actualStartAt;
+    private LocalDateTime actualEndAt;
     private String status;
     private BigDecimal priceBase;
     private BigDecimal priceDiscount;

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/BookingEventEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/BookingEventEntity.java
@@ -1,0 +1,22 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("booking_events")
+public class BookingEventEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String eventId;
+    private String bookingId;
+    private String eventType;
+    private String actorUserId;
+    private String actorRole;
+    private String details;
+    private LocalDateTime createdAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/DiscountRuleEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/DiscountRuleEntity.java
@@ -1,0 +1,23 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@TableName("discount_rules")
+public class DiscountRuleEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String discountRuleId;
+    private String type;
+    private BigDecimal thresholdHoursPerWeek;
+    private BigDecimal percentage;
+    private Integer active;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/IdempotencyKeyEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/IdempotencyKeyEntity.java
@@ -1,0 +1,21 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("idempotency_keys")
+public class IdempotencyKeyEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String idempotencyKey;
+    private String scope;
+    private String requestHash;
+    private Integer responseCode;
+    private String responseRef;
+    private LocalDateTime createdAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/IssueCommentEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/IssueCommentEntity.java
@@ -1,0 +1,21 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("issue_comments")
+public class IssueCommentEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String commentId;
+    private String issueId;
+    private String authorUserId;
+    private String authorRole;
+    private String message;
+    private LocalDateTime createdAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/IssueEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/IssueEntity.java
@@ -1,0 +1,26 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("issues")
+public class IssueEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String issueId;
+    private String reporterUserId;
+    private String bookingId;
+    private String scooterId;
+    private String title;
+    private String description;
+    private String priority;
+    private String status;
+    private String managerFeedback;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/NotificationEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/NotificationEntity.java
@@ -1,0 +1,24 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("notifications")
+public class NotificationEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String notificationId;
+    private String userId;
+    private String type;
+    private String title;
+    private String message;
+    private Integer readFlag;
+    private String relatedBookingId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/PasswordResetTokenEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/PasswordResetTokenEntity.java
@@ -1,0 +1,22 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("password_reset_tokens")
+public class PasswordResetTokenEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String resetTokenId;
+    private String userId;
+    private String resetToken;
+    private LocalDateTime expiresAt;
+    private Integer used;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/PaymentEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/PaymentEntity.java
@@ -1,0 +1,27 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@TableName("payments")
+public class PaymentEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String paymentId;
+    private String bookingId;
+    private String userId;
+    private BigDecimal amount;
+    private String method;
+    private String paymentMethodId;
+    private String status;
+    private String simulatedOutcome;
+    private BigDecimal refundedAmount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/entity/PaymentMethodEntity.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/entity/PaymentMethodEntity.java
@@ -1,0 +1,26 @@
+package com.lcyhz.urbanova.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("payment_methods")
+public class PaymentMethodEntity {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String paymentMethodId;
+    private String userId;
+    private String brand;
+    private String last4;
+    private Integer expiryMonth;
+    private Integer expiryYear;
+    private String label;
+    private Integer isDefault;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/AuditLogMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/AuditLogMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.AuditLogEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AuditLogMapper extends BaseMapper<AuditLogEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/AuthSessionMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/AuthSessionMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.AuthSessionEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AuthSessionMapper extends BaseMapper<AuthSessionEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/BookingConfirmationMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/BookingConfirmationMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.BookingConfirmationEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface BookingConfirmationMapper extends BaseMapper<BookingConfirmationEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/BookingEventMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/BookingEventMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.BookingEventEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface BookingEventMapper extends BaseMapper<BookingEventEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/DiscountRuleMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/DiscountRuleMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.DiscountRuleEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DiscountRuleMapper extends BaseMapper<DiscountRuleEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/IdempotencyKeyMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/IdempotencyKeyMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.IdempotencyKeyEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface IdempotencyKeyMapper extends BaseMapper<IdempotencyKeyEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/IssueCommentMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/IssueCommentMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.IssueCommentEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface IssueCommentMapper extends BaseMapper<IssueCommentEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/IssueMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/IssueMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.IssueEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface IssueMapper extends BaseMapper<IssueEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/NotificationMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/NotificationMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.NotificationEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface NotificationMapper extends BaseMapper<NotificationEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/PasswordResetTokenMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/PasswordResetTokenMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.PasswordResetTokenEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PasswordResetTokenMapper extends BaseMapper<PasswordResetTokenEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/PaymentMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/PaymentMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.PaymentEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PaymentMapper extends BaseMapper<PaymentEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/mapper/PaymentMethodMapper.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/mapper/PaymentMethodMapper.java
@@ -1,0 +1,9 @@
+package com.lcyhz.urbanova.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lcyhz.urbanova.entity.PaymentMethodEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PaymentMethodMapper extends BaseMapper<PaymentMethodEntity> {
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/security/AuthContext.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/security/AuthContext.java
@@ -4,6 +4,8 @@ import com.lcyhz.urbanova.common.exception.BusinessException;
 import com.lcyhz.urbanova.common.exception.ErrorCodes;
 import org.springframework.http.HttpStatus;
 
+import java.util.Set;
+
 public final class AuthContext {
     private static final ThreadLocal<AuthUser> CURRENT_USER = new ThreadLocal<>();
 
@@ -33,6 +35,13 @@ public final class AuthContext {
     public static void requireRole(String role) {
         AuthUser authUser = getRequiredUser();
         if (!role.equals(authUser.getRole())) {
+            throw new BusinessException(HttpStatus.FORBIDDEN.value(), ErrorCodes.AUTH_FORBIDDEN, "No permission for this operation");
+        }
+    }
+
+    public static void requireAnyRole(String... roles) {
+        AuthUser authUser = getRequiredUser();
+        if (!Set.of(roles).contains(authUser.getRole())) {
             throw new BusinessException(HttpStatus.FORBIDDEN.value(), ErrorCodes.AUTH_FORBIDDEN, "No permission for this operation");
         }
     }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/security/AuthInterceptor.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/security/AuthInterceptor.java
@@ -66,13 +66,34 @@ public class AuthInterceptor implements HandlerInterceptor {
         if ("POST".equalsIgnoreCase(method) && "/api/v1/auth/login".equals(path)) {
             return true;
         }
+        if ("POST".equalsIgnoreCase(method) && "/api/v1/auth/refresh".equals(path)) {
+            return true;
+        }
+        if ("POST".equalsIgnoreCase(method) && "/api/v1/auth/password/forgot".equals(path)) {
+            return true;
+        }
+        if ("POST".equalsIgnoreCase(method) && "/api/v1/auth/password/reset".equals(path)) {
+            return true;
+        }
         if ("GET".equalsIgnoreCase(method) && "/api/v1/hire-options".equals(path)) {
+            return true;
+        }
+        if ("GET".equalsIgnoreCase(method) && "/api/v1/scooters".equals(path)) {
             return true;
         }
         if ("GET".equalsIgnoreCase(method) && "/api/v1/scooters/ids".equals(path)) {
             return true;
         }
+        if ("GET".equalsIgnoreCase(method) && "/api/v1/scooters/availability".equals(path)) {
+            return true;
+        }
         if ("GET".equalsIgnoreCase(method) && "/api/v1/scooters/map-points".equals(path)) {
+            return true;
+        }
+        if ("GET".equalsIgnoreCase(method) && path.startsWith("/api/v1/scooters/")) {
+            return true;
+        }
+        if ("POST".equalsIgnoreCase(method) && "/api/v1/pricing/quotes".equals(path)) {
             return true;
         }
         if ("GET".equalsIgnoreCase(method) && "/api/v1/scooter-types".equals(path)) {
@@ -81,7 +102,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         if ("GET".equalsIgnoreCase(method) && path.startsWith("/api/v1/scooter-types/")) {
             return true;
         }
-        if ("POST".equalsIgnoreCase(method) && "/api/v1/pricing/quotes".equals(path)) {
+        if ("GET".equalsIgnoreCase(method) && "/api/v1/meta".equals(path)) {
             return true;
         }
         return "GET".equalsIgnoreCase(method) && "/api/v1/health".equals(path);

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/AnalyticsService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/AnalyticsService.java
@@ -1,0 +1,165 @@
+package com.lcyhz.urbanova.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.entity.BookingEntity;
+import com.lcyhz.urbanova.entity.DiscountRuleEntity;
+import com.lcyhz.urbanova.entity.HireOptionEntity;
+import com.lcyhz.urbanova.entity.PaymentEntity;
+import com.lcyhz.urbanova.entity.UserEntity;
+import com.lcyhz.urbanova.mapper.BookingMapper;
+import com.lcyhz.urbanova.mapper.DiscountRuleMapper;
+import com.lcyhz.urbanova.mapper.HireOptionMapper;
+import com.lcyhz.urbanova.mapper.PaymentMapper;
+import com.lcyhz.urbanova.mapper.UserMapper;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class AnalyticsService {
+    private final PaymentMapper paymentMapper;
+    private final BookingMapper bookingMapper;
+    private final HireOptionMapper hireOptionMapper;
+    private final UserMapper userMapper;
+    private final DiscountRuleMapper discountRuleMapper;
+    private final DiscountRuleService discountRuleService;
+
+    public AnalyticsService(PaymentMapper paymentMapper,
+                            BookingMapper bookingMapper,
+                            HireOptionMapper hireOptionMapper,
+                            UserMapper userMapper,
+                            DiscountRuleMapper discountRuleMapper,
+                            DiscountRuleService discountRuleService) {
+        this.paymentMapper = paymentMapper;
+        this.bookingMapper = bookingMapper;
+        this.hireOptionMapper = hireOptionMapper;
+        this.userMapper = userMapper;
+        this.discountRuleMapper = discountRuleMapper;
+        this.discountRuleService = discountRuleService;
+    }
+
+    public Map<String, Object> revenueEstimate(LocalDate startDate, LocalDate endDate) {
+        LocalDate resolvedStart = startDate == null ? LocalDate.now().minusDays(6) : startDate;
+        LocalDate resolvedEnd = endDate == null ? LocalDate.now() : endDate;
+        BigDecimal total = paymentsInRange(resolvedStart, resolvedEnd).stream()
+                .map(this::netPayment)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(2, RoundingMode.HALF_UP);
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("startDate", resolvedStart);
+        data.put("endDate", resolvedEnd);
+        data.put("currency", DomainConstants.CURRENCY_GBP);
+        data.put("estimatedRevenue", total);
+        return data;
+    }
+
+    public List<Map<String, Object>> weeklyByHireOption(LocalDate startDate) {
+        LocalDate resolvedStart = startDate == null ? LocalDate.now().minusDays(6) : startDate;
+        LocalDate resolvedEnd = resolvedStart.plusDays(6);
+        Map<String, BookingEntity> bookingMap = bookingMapper.selectList(new LambdaQueryWrapper<BookingEntity>())
+                .stream().collect(Collectors.toMap(BookingEntity::getBookingId, Function.identity()));
+        Map<String, HireOptionEntity> hireMap = hireOptionMapper.selectList(new LambdaQueryWrapper<HireOptionEntity>())
+                .stream().collect(Collectors.toMap(HireOptionEntity::getHireOptionId, Function.identity()));
+        Map<String, BigDecimal> totals = new LinkedHashMap<>();
+        for (HireOptionEntity hireOption : hireMap.values()) {
+            totals.put(hireOption.getCode(), BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+        }
+        for (PaymentEntity payment : paymentsInRange(resolvedStart, resolvedEnd)) {
+            BookingEntity booking = bookingMap.get(payment.getBookingId());
+            if (booking == null) {
+                continue;
+            }
+            HireOptionEntity hireOption = hireMap.get(booking.getHireOptionId());
+            if (hireOption == null) {
+                continue;
+            }
+            totals.put(hireOption.getCode(), totals.getOrDefault(hireOption.getCode(), BigDecimal.ZERO).add(netPayment(payment)).setScale(2, RoundingMode.HALF_UP));
+        }
+        List<Map<String, Object>> data = new ArrayList<>();
+        totals.forEach((code, total) -> {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("hireOptionCode", code);
+            row.put("weeklyRevenue", total);
+            row.put("startDate", resolvedStart);
+            row.put("endDate", resolvedEnd);
+            data.add(row);
+        });
+        return data;
+    }
+
+    public List<Map<String, Object>> dailyCombined(LocalDate startDate) {
+        LocalDate resolvedStart = startDate == null ? LocalDate.now().minusDays(6) : startDate;
+        LocalDate resolvedEnd = resolvedStart.plusDays(6);
+        List<Map<String, Object>> data = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            LocalDate day = resolvedStart.plusDays(i);
+            BigDecimal total = paymentsInRange(day, day).stream().map(this::netPayment).reduce(BigDecimal.ZERO, BigDecimal::add).setScale(2, RoundingMode.HALF_UP);
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("date", day);
+            row.put("dailyRevenue", total);
+            data.add(row);
+        }
+        return data;
+    }
+
+    public Map<String, Object> weeklyChart(LocalDate startDate) {
+        List<Map<String, Object>> points = dailyCombined(startDate);
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("series", points);
+        data.put("currency", DomainConstants.CURRENCY_GBP);
+        return data;
+    }
+
+    public List<Map<String, Object>> frequentUsers() {
+        DiscountRuleEntity frequentRule = discountRuleMapper.selectOne(new LambdaQueryWrapper<DiscountRuleEntity>()
+                .eq(DiscountRuleEntity::getType, DomainConstants.DiscountRuleType.FREQUENT_USER)
+                .eq(DiscountRuleEntity::getActive, 1));
+        BigDecimal threshold = frequentRule == null || frequentRule.getThresholdHoursPerWeek() == null
+                ? BigDecimal.valueOf(8).setScale(2, RoundingMode.HALF_UP)
+                : frequentRule.getThresholdHoursPerWeek();
+        return userMapper.selectList(new LambdaQueryWrapper<UserEntity>()
+                        .eq(UserEntity::getRole, DomainConstants.ROLE_CUSTOMER)
+                        .eq(UserEntity::getAccountStatus, DomainConstants.ACCOUNT_ACTIVE))
+                .stream()
+                .map(user -> {
+                    BigDecimal hours = discountRuleService.calculateRecentHours(user.getUserId());
+                    if (hours.compareTo(threshold) < 0) {
+                        return null;
+                    }
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("userId", user.getUserId());
+                    row.put("email", user.getEmail());
+                    row.put("fullName", user.getFullName());
+                    row.put("hoursLast7Days", hours);
+                    row.put("thresholdHours", threshold);
+                    return row;
+                })
+                .filter(java.util.Objects::nonNull)
+                .toList();
+    }
+
+    private List<PaymentEntity> paymentsInRange(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime startAt = startDate.atStartOfDay();
+        LocalDateTime endAt = endDate.plusDays(1).atStartOfDay();
+        return paymentMapper.selectList(new LambdaQueryWrapper<PaymentEntity>()
+                .in(PaymentEntity::getStatus, DomainConstants.PaymentStatus.SUCCEEDED, DomainConstants.PaymentStatus.REFUNDED)
+                .ge(PaymentEntity::getCreatedAt, startAt)
+                .lt(PaymentEntity::getCreatedAt, endAt));
+    }
+
+    private BigDecimal netPayment(PaymentEntity payment) {
+        return payment.getAmount().subtract(payment.getRefundedAmount() == null ? BigDecimal.ZERO : payment.getRefundedAmount())
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/AuthService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/AuthService.java
@@ -5,10 +5,20 @@ import com.lcyhz.urbanova.dto.auth.RegisterRequest;
 import com.lcyhz.urbanova.vo.auth.AuthPayload;
 import com.lcyhz.urbanova.vo.auth.UserProfileVo;
 
+import java.util.Map;
+
 public interface AuthService {
     AuthPayload register(RegisterRequest request);
 
     AuthPayload login(LoginRequest request);
+
+    AuthPayload refresh(String refreshToken);
+
+    Map<String, Object> logout(String userId, String refreshToken);
+
+    Map<String, Object> forgotPassword(String email);
+
+    Map<String, Object> resetPassword(String resetToken, String newPassword);
 
     UserProfileVo getCurrentUser(String userId);
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/BookingService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/BookingService.java
@@ -3,12 +3,13 @@ package com.lcyhz.urbanova.service;
 import com.lcyhz.urbanova.dto.booking.CancelBookingRequest;
 import com.lcyhz.urbanova.dto.booking.CreateBookingRequest;
 import com.lcyhz.urbanova.dto.booking.UpdateBookingRequest;
-import com.lcyhz.urbanova.vo.booking.CancelBookingVo;
 import com.lcyhz.urbanova.vo.booking.BookingDetailVo;
 import com.lcyhz.urbanova.vo.booking.BookingListItemVo;
+import com.lcyhz.urbanova.vo.booking.CancelBookingVo;
 import com.lcyhz.urbanova.vo.booking.CreateBookingVo;
 
 import java.util.List;
+import java.util.Map;
 
 public interface BookingService {
     CreateBookingVo createBooking(String userId, CreateBookingRequest request);
@@ -20,4 +21,28 @@ public interface BookingService {
     BookingDetailVo updateBooking(String userId, String bookingId, UpdateBookingRequest request);
 
     CancelBookingVo cancelBooking(String userId, String bookingId, CancelBookingRequest request);
+
+    Map<String, Object> startBooking(String userId, String role, String bookingId);
+
+    Map<String, Object> endBooking(String userId, String role, String bookingId);
+
+    Map<String, Object> extendBooking(String userId, String role, String bookingId, Map<String, Object> request);
+
+    List<Map<String, Object>> getBookingTimeline(String userId, String role, String bookingId);
+
+    Map<String, Object> createGuestBooking(String staffUserId, Map<String, Object> request);
+
+    Map<String, Object> getGuestBookingDetail(String staffUserId, String bookingId);
+
+    List<Map<String, Object>> listAdminBookings(String status, String paymentStatus, String customerType);
+
+    Map<String, Object> getAdminBookingDetail(String bookingId);
+
+    Map<String, Object> overrideBooking(String bookingId, Map<String, Object> request);
+
+    Map<String, Object> getBookingConfirmation(String userId, String role, String bookingId);
+
+    Map<String, Object> resendBookingConfirmation(String userId, String role, String bookingId);
+
+    List<Map<String, Object>> listConfirmations(String userId);
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/DiscountRuleService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/DiscountRuleService.java
@@ -1,0 +1,266 @@
+package com.lcyhz.urbanova.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.lcyhz.urbanova.common.exception.BusinessException;
+import com.lcyhz.urbanova.common.exception.ErrorCodes;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.entity.BookingEntity;
+import com.lcyhz.urbanova.entity.DiscountRuleEntity;
+import com.lcyhz.urbanova.entity.UserEntity;
+import com.lcyhz.urbanova.mapper.BookingMapper;
+import com.lcyhz.urbanova.mapper.DiscountRuleMapper;
+import com.lcyhz.urbanova.mapper.UserMapper;
+import com.lcyhz.urbanova.vo.pricing.AppliedDiscountVo;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class DiscountRuleService {
+    private final DiscountRuleMapper discountRuleMapper;
+    private final BookingMapper bookingMapper;
+    private final UserMapper userMapper;
+
+    public DiscountRuleService(DiscountRuleMapper discountRuleMapper, BookingMapper bookingMapper, UserMapper userMapper) {
+        this.discountRuleMapper = discountRuleMapper;
+        this.bookingMapper = bookingMapper;
+        this.userMapper = userMapper;
+    }
+
+    public DiscountComputation calculateForUser(String userId, BigDecimal basePrice) {
+        if (userId == null) {
+            return new DiscountComputation(basePrice, BigDecimal.ZERO, basePrice, List.of(), List.of(), BigDecimal.ZERO);
+        }
+
+        UserEntity user = userMapper.selectOne(new LambdaQueryWrapper<UserEntity>()
+                .eq(UserEntity::getUserId, userId));
+        if (user == null) {
+            return new DiscountComputation(basePrice, BigDecimal.ZERO, basePrice, List.of(), List.of(), BigDecimal.ZERO);
+        }
+
+        Map<String, DiscountRuleEntity> activeRuleMap = discountRuleMapper.selectList(new LambdaQueryWrapper<DiscountRuleEntity>()
+                        .eq(DiscountRuleEntity::getActive, 1))
+                .stream()
+                .collect(Collectors.toMap(DiscountRuleEntity::getType, Function.identity(), (left, right) -> left, LinkedHashMap::new));
+
+        BigDecimal recentHours = calculateRecentHours(userId);
+        List<AppliedDiscountVo> applied = new ArrayList<>();
+        LinkedHashSet<String> eligibleTypes = new LinkedHashSet<>();
+        BigDecimal totalPercentage = BigDecimal.ZERO;
+
+        DiscountRuleEntity frequentRule = activeRuleMap.get(DomainConstants.DiscountRuleType.FREQUENT_USER);
+        if (frequentRule != null && frequentRule.getThresholdHoursPerWeek() != null
+                && recentHours.compareTo(frequentRule.getThresholdHoursPerWeek()) >= 0) {
+            eligibleTypes.add(frequentRule.getType());
+            totalPercentage = totalPercentage.add(zeroIfNull(frequentRule.getPercentage()));
+        }
+
+        String category = user.getDiscountCategory();
+        if (DomainConstants.DISCOUNT_STUDENT.equals(category)) {
+            DiscountRuleEntity rule = activeRuleMap.get(DomainConstants.DiscountRuleType.STUDENT);
+            if (rule != null) {
+                eligibleTypes.add(rule.getType());
+                totalPercentage = totalPercentage.add(zeroIfNull(rule.getPercentage()));
+            }
+        }
+        if (DomainConstants.DISCOUNT_SENIOR.equals(category)) {
+            DiscountRuleEntity rule = activeRuleMap.get(DomainConstants.DiscountRuleType.SENIOR);
+            if (rule != null) {
+                eligibleTypes.add(rule.getType());
+                totalPercentage = totalPercentage.add(zeroIfNull(rule.getPercentage()));
+            }
+        }
+
+        BigDecimal totalDiscount = BigDecimal.ZERO;
+        for (String type : eligibleTypes) {
+            DiscountRuleEntity rule = activeRuleMap.get(type);
+            BigDecimal amount = basePrice.multiply(zeroIfNull(rule.getPercentage()))
+                    .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+            applied.add(new AppliedDiscountVo(type, amount));
+            totalDiscount = totalDiscount.add(amount);
+        }
+        BigDecimal finalPrice = basePrice.subtract(totalDiscount).max(BigDecimal.ZERO).setScale(2, RoundingMode.HALF_UP);
+        return new DiscountComputation(recentHours, totalDiscount, finalPrice, applied, List.copyOf(eligibleTypes), totalPercentage);
+    }
+
+    public Map<String, Object> getEligibility(String userId) {
+        UserEntity user = userMapper.selectOne(new LambdaQueryWrapper<UserEntity>()
+                .eq(UserEntity::getUserId, userId));
+        if (user == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "User not found");
+        }
+        DiscountComputation computation = calculateForUser(userId, BigDecimal.valueOf(100));
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("userId", userId);
+        data.put("discountCategory", user.getDiscountCategory());
+        data.put("hoursLast7Days", computation.recentHours());
+        data.put("eligibleTypes", computation.eligibleTypes());
+        data.put("estimatedPercentage", computation.totalPercentage());
+        data.put("activeRules", listRules());
+        return data;
+    }
+
+    public List<Map<String, Object>> listRules() {
+        return discountRuleMapper.selectList(new LambdaQueryWrapper<DiscountRuleEntity>()
+                        .orderByAsc(DiscountRuleEntity::getType))
+                .stream()
+                .map(this::toRuleMap)
+                .toList();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> createRule(Map<String, Object> request) {
+        String type = normalizeType(requireText(request.get("type"), "type"));
+        DiscountRuleEntity existing = discountRuleMapper.selectOne(new LambdaQueryWrapper<DiscountRuleEntity>()
+                .eq(DiscountRuleEntity::getType, type));
+        if (existing != null) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "Discount rule already exists");
+        }
+
+        DiscountRuleEntity entity = new DiscountRuleEntity();
+        entity.setDiscountRuleId("DISC-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase(Locale.ROOT));
+        entity.setType(type);
+        entity.setThresholdHoursPerWeek(parseBigDecimal(request.get("thresholdHoursPerWeek")));
+        entity.setPercentage(requireBigDecimal(request.get("percentage"), "percentage"));
+        entity.setActive(parseBooleanDefaultTrue(request.get("active")) ? 1 : 0);
+        entity.setCreatedAt(LocalDateTime.now());
+        entity.setUpdatedAt(LocalDateTime.now());
+        discountRuleMapper.insert(entity);
+        return toRuleMap(entity);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> updateRule(String discountRuleId, Map<String, Object> request) {
+        DiscountRuleEntity entity = discountRuleMapper.selectOne(new LambdaQueryWrapper<DiscountRuleEntity>()
+                .eq(DiscountRuleEntity::getDiscountRuleId, discountRuleId));
+        if (entity == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Discount rule not found");
+        }
+
+        if (request.containsKey("thresholdHoursPerWeek")) {
+            entity.setThresholdHoursPerWeek(parseBigDecimal(request.get("thresholdHoursPerWeek")));
+        }
+        if (request.containsKey("percentage")) {
+            entity.setPercentage(requireBigDecimal(request.get("percentage"), "percentage"));
+        }
+        if (request.containsKey("active")) {
+            entity.setActive(parseBooleanDefaultTrue(request.get("active")) ? 1 : 0);
+        }
+        entity.setUpdatedAt(LocalDateTime.now());
+        discountRuleMapper.updateById(entity);
+        return toRuleMap(entity);
+    }
+
+    public BigDecimal calculateRecentHours(String userId) {
+        LocalDateTime since = LocalDateTime.now().minusDays(7);
+        List<BookingEntity> bookings = bookingMapper.selectList(new LambdaQueryWrapper<BookingEntity>()
+                .eq(BookingEntity::getUserId, userId)
+                .ge(BookingEntity::getCreatedAt, since)
+                .in(BookingEntity::getStatus,
+                        DomainConstants.BookingStatus.PENDING_PAYMENT,
+                        DomainConstants.BookingStatus.CONFIRMED,
+                        DomainConstants.BookingStatus.ACTIVE,
+                        DomainConstants.BookingStatus.COMPLETED));
+
+        long totalMinutes = 0L;
+        for (BookingEntity booking : bookings) {
+            LocalDateTime start = booking.getActualStartAt() != null ? booking.getActualStartAt() : booking.getStartAt();
+            LocalDateTime end = booking.getActualEndAt() != null ? booking.getActualEndAt() : booking.getEndAt();
+            if (start != null && end != null && !end.isBefore(start)) {
+                totalMinutes += Duration.between(start, end).toMinutes();
+            }
+        }
+        return BigDecimal.valueOf(totalMinutes)
+                .divide(BigDecimal.valueOf(60), 2, RoundingMode.HALF_UP);
+    }
+
+    public Map<String, Object> toRuleMap(DiscountRuleEntity entity) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("discountRuleId", entity.getDiscountRuleId());
+        data.put("type", entity.getType());
+        data.put("thresholdHoursPerWeek", entity.getThresholdHoursPerWeek());
+        data.put("percentage", entity.getPercentage());
+        data.put("active", entity.getActive() != null && entity.getActive() == 1);
+        data.put("createdAt", entity.getCreatedAt());
+        data.put("updatedAt", entity.getUpdatedAt());
+        return data;
+    }
+
+    private BigDecimal zeroIfNull(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+
+    private String requireText(Object value, String field) {
+        if (value == null || String.valueOf(value).trim().isEmpty()) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        return String.valueOf(value).trim();
+    }
+
+    private String normalizeType(String value) {
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        Set<String> allowed = Set.of(
+                DomainConstants.DiscountRuleType.FREQUENT_USER,
+                DomainConstants.DiscountRuleType.STUDENT,
+                DomainConstants.DiscountRuleType.SENIOR
+        );
+        if (!allowed.contains(normalized)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR,
+                    "type must be FREQUENT_USER, STUDENT, or SENIOR");
+        }
+        return normalized;
+    }
+
+    private BigDecimal requireBigDecimal(Object value, String field) {
+        BigDecimal parsed = parseBigDecimal(value);
+        if (parsed == null) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        return parsed.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal parseBigDecimal(Object value) {
+        if (value == null || String.valueOf(value).trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(String.valueOf(value).trim());
+        } catch (NumberFormatException ex) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR,
+                    "Invalid decimal value: " + value);
+        }
+    }
+
+    private boolean parseBooleanDefaultTrue(Object value) {
+        if (value == null) {
+            return true;
+        }
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        return Boolean.parseBoolean(String.valueOf(value));
+    }
+
+    public record DiscountComputation(BigDecimal recentHours,
+                                      BigDecimal totalDiscount,
+                                      BigDecimal finalPrice,
+                                      List<AppliedDiscountVo> appliedDiscounts,
+                                      List<String> eligibleTypes,
+                                      BigDecimal totalPercentage) {
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/HireOptionService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/HireOptionService.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface HireOptionService {
     List<HireOptionVo> listActiveHireOptions();
 
-    PriceQuoteVo quotePrice(PriceQuoteRequest request);
+    PriceQuoteVo quotePrice(String userId, PriceQuoteRequest request);
 
     List<AdminHireOptionVo> listAllHireOptions();
 

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/IssueManagementService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/IssueManagementService.java
@@ -1,0 +1,240 @@
+package com.lcyhz.urbanova.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.lcyhz.urbanova.common.exception.BusinessException;
+import com.lcyhz.urbanova.common.exception.ErrorCodes;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.entity.IssueCommentEntity;
+import com.lcyhz.urbanova.entity.IssueEntity;
+import com.lcyhz.urbanova.mapper.IssueCommentMapper;
+import com.lcyhz.urbanova.mapper.IssueMapper;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class IssueManagementService {
+    private final IssueMapper issueMapper;
+    private final IssueCommentMapper issueCommentMapper;
+    private final PlatformSupportService platformSupportService;
+
+    public IssueManagementService(IssueMapper issueMapper,
+                                  IssueCommentMapper issueCommentMapper,
+                                  PlatformSupportService platformSupportService) {
+        this.issueMapper = issueMapper;
+        this.issueCommentMapper = issueCommentMapper;
+        this.platformSupportService = platformSupportService;
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> createIssue(String userId, Map<String, Object> request) {
+        IssueEntity issue = new IssueEntity();
+        issue.setIssueId("ISS-" + UUID.randomUUID().toString().replace("-", "").substring(0, 10).toUpperCase(Locale.ROOT));
+        issue.setReporterUserId(userId);
+        issue.setBookingId(trimToNull(stringValue(request.get("bookingId"))));
+        issue.setScooterId(trimToNull(stringValue(request.get("scooterId"))));
+        issue.setTitle(requireText(stringValue(request.get("title")), "title"));
+        issue.setDescription(requireText(stringValue(request.get("description")), "description"));
+        issue.setPriority(normalizePriority(stringValue(request.get("priority")), DomainConstants.IssuePriority.LOW));
+        issue.setStatus(DomainConstants.IssueStatus.OPEN);
+        issue.setCreatedAt(LocalDateTime.now());
+        issue.setUpdatedAt(LocalDateTime.now());
+        issueMapper.insert(issue);
+        return toIssueMap(issue, List.of());
+    }
+
+    public List<Map<String, Object>> listOwnIssues(String userId, String status) {
+        LambdaQueryWrapper<IssueEntity> query = new LambdaQueryWrapper<IssueEntity>()
+                .eq(IssueEntity::getReporterUserId, userId)
+                .orderByDesc(IssueEntity::getUpdatedAt);
+        if (hasText(status)) {
+            query.eq(IssueEntity::getStatus, status.trim().toUpperCase(Locale.ROOT));
+        }
+        return issueMapper.selectList(query).stream().map(issue -> toIssueMap(issue, null)).toList();
+    }
+
+    public Map<String, Object> getIssue(String userId, String role, String issueId) {
+        IssueEntity issue = requireIssue(issueId);
+        if (!DomainConstants.ROLE_MANAGER.equals(role) && !issue.getReporterUserId().equals(userId)) {
+            throw new BusinessException(HttpStatus.FORBIDDEN.value(), ErrorCodes.AUTH_FORBIDDEN, "No permission for this issue");
+        }
+        return toIssueMap(issue, loadComments(issueId));
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> addComment(String userId, String role, String issueId, String message) {
+        IssueEntity issue = requireIssue(issueId);
+        if (!DomainConstants.ROLE_MANAGER.equals(role) && !issue.getReporterUserId().equals(userId)) {
+            throw new BusinessException(HttpStatus.FORBIDDEN.value(), ErrorCodes.AUTH_FORBIDDEN, "No permission for this issue");
+        }
+        IssueCommentEntity comment = new IssueCommentEntity();
+        comment.setCommentId("COM-" + UUID.randomUUID().toString().replace("-", "").substring(0, 10).toUpperCase(Locale.ROOT));
+        comment.setIssueId(issueId);
+        comment.setAuthorUserId(userId);
+        comment.setAuthorRole(role);
+        comment.setMessage(requireText(message, "message"));
+        comment.setCreatedAt(LocalDateTime.now());
+        issueCommentMapper.insert(comment);
+        issue.setUpdatedAt(LocalDateTime.now());
+        issueMapper.updateById(issue);
+        if (DomainConstants.ROLE_MANAGER.equals(role)) {
+            platformSupportService.createNotification(issue.getReporterUserId(), DomainConstants.NotificationType.ISSUE_UPDATED,
+                    "Issue updated", "Manager added a comment to issue " + issue.getIssueId(), issue.getBookingId());
+        }
+        return toIssueMap(issue, loadComments(issueId));
+    }
+
+    public List<Map<String, Object>> listAdminIssues(String status, String priority) {
+        LambdaQueryWrapper<IssueEntity> query = new LambdaQueryWrapper<IssueEntity>()
+                .orderByDesc(IssueEntity::getUpdatedAt);
+        if (hasText(status)) {
+            query.eq(IssueEntity::getStatus, status.trim().toUpperCase(Locale.ROOT));
+        }
+        if (hasText(priority)) {
+            query.eq(IssueEntity::getPriority, priority.trim().toUpperCase(Locale.ROOT));
+        }
+        return issueMapper.selectList(query).stream().map(issue -> toIssueMap(issue, null)).toList();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> updatePriority(String issueId, String priority) {
+        IssueEntity issue = requireIssue(issueId);
+        issue.setPriority(normalizePriority(priority, issue.getPriority()));
+        issue.setUpdatedAt(LocalDateTime.now());
+        issueMapper.updateById(issue);
+        platformSupportService.recordAudit("ISSUE_PRIORITY_UPDATED", "ISSUE", issueId, "priority=" + issue.getPriority());
+        platformSupportService.createNotification(issue.getReporterUserId(), DomainConstants.NotificationType.ISSUE_UPDATED,
+                "Issue priority updated", "Priority changed for issue " + issue.getIssueId(), issue.getBookingId());
+        return toIssueMap(issue, loadComments(issueId));
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> updateStatus(String issueId, String status) {
+        IssueEntity issue = requireIssue(issueId);
+        issue.setStatus(normalizeStatus(status));
+        issue.setUpdatedAt(LocalDateTime.now());
+        issueMapper.updateById(issue);
+        platformSupportService.recordAudit("ISSUE_STATUS_UPDATED", "ISSUE", issueId, "status=" + issue.getStatus());
+        platformSupportService.createNotification(issue.getReporterUserId(), DomainConstants.NotificationType.ISSUE_UPDATED,
+                "Issue status updated", "Status changed for issue " + issue.getIssueId(), issue.getBookingId());
+        return toIssueMap(issue, loadComments(issueId));
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> resolve(String issueId, String feedback) {
+        IssueEntity issue = requireIssue(issueId);
+        issue.setStatus(DomainConstants.IssueStatus.RESOLVED);
+        issue.setManagerFeedback(trimToNull(feedback));
+        issue.setUpdatedAt(LocalDateTime.now());
+        issueMapper.updateById(issue);
+        platformSupportService.recordAudit("ISSUE_RESOLVED", "ISSUE", issueId, feedback);
+        platformSupportService.createNotification(issue.getReporterUserId(), DomainConstants.NotificationType.ISSUE_UPDATED,
+                "Issue resolved", "Issue " + issue.getIssueId() + " was resolved", issue.getBookingId());
+        return toIssueMap(issue, loadComments(issueId));
+    }
+
+    public List<Map<String, Object>> listHighPriorityIssues() {
+        return issueMapper.selectList(new LambdaQueryWrapper<IssueEntity>()
+                        .in(IssueEntity::getPriority, DomainConstants.IssuePriority.HIGH, DomainConstants.IssuePriority.CRITICAL)
+                        .orderByDesc(IssueEntity::getUpdatedAt))
+                .stream()
+                .map(issue -> toIssueMap(issue, null))
+                .toList();
+    }
+
+    private IssueEntity requireIssue(String issueId) {
+        IssueEntity issue = issueMapper.selectOne(new LambdaQueryWrapper<IssueEntity>()
+                .eq(IssueEntity::getIssueId, issueId));
+        if (issue == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Issue not found");
+        }
+        return issue;
+    }
+
+    private List<Map<String, Object>> loadComments(String issueId) {
+        return issueCommentMapper.selectList(new LambdaQueryWrapper<IssueCommentEntity>()
+                        .eq(IssueCommentEntity::getIssueId, issueId)
+                        .orderByAsc(IssueCommentEntity::getCreatedAt))
+                .stream()
+                .map(this::toCommentMap)
+                .toList();
+    }
+
+    private Map<String, Object> toIssueMap(IssueEntity issue, List<Map<String, Object>> comments) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("issueId", issue.getIssueId());
+        data.put("reporterUserId", issue.getReporterUserId());
+        data.put("bookingId", issue.getBookingId());
+        data.put("scooterId", issue.getScooterId());
+        data.put("title", issue.getTitle());
+        data.put("description", issue.getDescription());
+        data.put("priority", issue.getPriority());
+        data.put("status", issue.getStatus());
+        data.put("managerFeedback", issue.getManagerFeedback());
+        data.put("createdAt", issue.getCreatedAt());
+        data.put("updatedAt", issue.getUpdatedAt());
+        if (comments != null) {
+            data.put("comments", comments);
+        }
+        return data;
+    }
+
+    private Map<String, Object> toCommentMap(IssueCommentEntity comment) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("commentId", comment.getCommentId());
+        data.put("issueId", comment.getIssueId());
+        data.put("authorUserId", comment.getAuthorUserId());
+        data.put("authorRole", comment.getAuthorRole());
+        data.put("message", comment.getMessage());
+        data.put("createdAt", comment.getCreatedAt());
+        return data;
+    }
+
+    private String requireText(String value, String field) {
+        if (!hasText(value)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        return value.trim();
+    }
+
+    private String normalizePriority(String value, String fallback) {
+        String resolved = hasText(value) ? value.trim().toUpperCase(Locale.ROOT) : fallback;
+        if (!Set.of(DomainConstants.IssuePriority.LOW, DomainConstants.IssuePriority.HIGH, DomainConstants.IssuePriority.CRITICAL).contains(resolved)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "Invalid issue priority");
+        }
+        return resolved;
+    }
+
+    private String normalizeStatus(String value) {
+        String resolved = requireText(value, "status").toUpperCase(Locale.ROOT);
+        if (!Set.of(DomainConstants.IssueStatus.OPEN, DomainConstants.IssueStatus.IN_REVIEW, DomainConstants.IssueStatus.RESOLVED, DomainConstants.IssueStatus.CLOSED).contains(resolved)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "Invalid issue status");
+        }
+        return resolved;
+    }
+
+    private String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/NotificationService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/NotificationService.java
@@ -1,0 +1,44 @@
+package com.lcyhz.urbanova.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.lcyhz.urbanova.common.exception.BusinessException;
+import com.lcyhz.urbanova.common.exception.ErrorCodes;
+import com.lcyhz.urbanova.entity.NotificationEntity;
+import com.lcyhz.urbanova.mapper.NotificationMapper;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class NotificationService {
+    private final NotificationMapper notificationMapper;
+    private final PlatformSupportService platformSupportService;
+
+    public NotificationService(NotificationMapper notificationMapper, PlatformSupportService platformSupportService) {
+        this.notificationMapper = notificationMapper;
+        this.platformSupportService = platformSupportService;
+    }
+
+    public List<Map<String, Object>> listNotifications(String userId) {
+        return platformSupportService.listNotifications(userId);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> markRead(String userId, String notificationId) {
+        NotificationEntity notification = notificationMapper.selectOne(new LambdaQueryWrapper<NotificationEntity>()
+                .eq(NotificationEntity::getNotificationId, notificationId)
+                .eq(NotificationEntity::getUserId, userId));
+        if (notification == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Notification not found");
+        }
+        notification.setReadFlag(1);
+        notification.setUpdatedAt(LocalDateTime.now());
+        notificationMapper.updateById(notification);
+        return platformSupportService.toNotificationMap(notification);
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/PaymentMethodService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/PaymentMethodService.java
@@ -1,0 +1,209 @@
+package com.lcyhz.urbanova.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.lcyhz.urbanova.common.exception.BusinessException;
+import com.lcyhz.urbanova.common.exception.ErrorCodes;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.entity.PaymentMethodEntity;
+import com.lcyhz.urbanova.mapper.PaymentMethodMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class PaymentMethodService {
+    private final PaymentMethodMapper paymentMethodMapper;
+
+    public PaymentMethodService(PaymentMethodMapper paymentMethodMapper) {
+        this.paymentMethodMapper = paymentMethodMapper;
+    }
+
+    public List<Map<String, Object>> listPaymentMethods(String userId) {
+        return paymentMethodMapper.selectList(new LambdaQueryWrapper<PaymentMethodEntity>()
+                        .eq(PaymentMethodEntity::getUserId, userId)
+                        .ne(PaymentMethodEntity::getStatus, DomainConstants.PaymentMethodStatus.REMOVED)
+                        .orderByDesc(PaymentMethodEntity::getIsDefault)
+                        .orderByDesc(PaymentMethodEntity::getUpdatedAt))
+                .stream()
+                .map(this::toMap)
+                .toList();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> createPaymentMethod(String userId, Map<String, Object> request) {
+        String brand = requireText(request.get("brand"), "brand").toUpperCase(Locale.ROOT);
+        String cardNumber = requireText(request.get("cardNumber"), "cardNumber").replaceAll("\\s+", "");
+        if (cardNumber.length() < 4) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "cardNumber must contain at least 4 digits");
+        }
+
+        PaymentMethodEntity entity = new PaymentMethodEntity();
+        entity.setPaymentMethodId("PM-" + UUID.randomUUID().toString().replace("-", "").substring(0, 10).toUpperCase(Locale.ROOT));
+        entity.setUserId(userId);
+        entity.setBrand(brand);
+        entity.setLast4(cardNumber.substring(cardNumber.length() - 4));
+        entity.setExpiryMonth(requireInteger(request.get("expiryMonth"), "expiryMonth"));
+        entity.setExpiryYear(requireInteger(request.get("expiryYear"), "expiryYear"));
+        entity.setLabel(trimToNull((String) request.get("label")));
+        entity.setStatus(DomainConstants.PaymentMethodStatus.ACTIVE);
+        entity.setIsDefault(parseBoolean(request.get("isDefault")) ? 1 : 0);
+        entity.setCreatedAt(LocalDateTime.now());
+        entity.setUpdatedAt(LocalDateTime.now());
+        if (entity.getIsDefault() == 1 || !hasAnyDefault(userId)) {
+            clearDefault(userId);
+            entity.setIsDefault(1);
+        }
+        paymentMethodMapper.insert(entity);
+        return toMap(entity);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> updatePaymentMethod(String userId, String paymentMethodId, Map<String, Object> request) {
+        PaymentMethodEntity entity = requireOwnedMethod(userId, paymentMethodId);
+        if (request.containsKey("expiryMonth")) {
+            entity.setExpiryMonth(requireInteger(request.get("expiryMonth"), "expiryMonth"));
+        }
+        if (request.containsKey("expiryYear")) {
+            entity.setExpiryYear(requireInteger(request.get("expiryYear"), "expiryYear"));
+        }
+        if (request.containsKey("label")) {
+            entity.setLabel(trimToNull((String) request.get("label")));
+        }
+        if (request.containsKey("isDefault") && parseBoolean(request.get("isDefault"))) {
+            clearDefault(userId);
+            entity.setIsDefault(1);
+        }
+        entity.setUpdatedAt(LocalDateTime.now());
+        paymentMethodMapper.updateById(entity);
+        return toMap(entity);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> deletePaymentMethod(String userId, String paymentMethodId) {
+        PaymentMethodEntity entity = requireOwnedMethod(userId, paymentMethodId);
+        entity.setStatus(DomainConstants.PaymentMethodStatus.REMOVED);
+        entity.setIsDefault(0);
+        entity.setUpdatedAt(LocalDateTime.now());
+        paymentMethodMapper.updateById(entity);
+
+        if (!hasAnyDefault(userId)) {
+            PaymentMethodEntity replacement = paymentMethodMapper.selectOne(new LambdaQueryWrapper<PaymentMethodEntity>()
+                    .eq(PaymentMethodEntity::getUserId, userId)
+                    .eq(PaymentMethodEntity::getStatus, DomainConstants.PaymentMethodStatus.ACTIVE)
+                    .orderByDesc(PaymentMethodEntity::getUpdatedAt)
+                    .last("LIMIT 1"));
+            if (replacement != null) {
+                replacement.setIsDefault(1);
+                replacement.setUpdatedAt(LocalDateTime.now());
+                paymentMethodMapper.updateById(replacement);
+            }
+        }
+        return toMap(entity);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> setDefault(String userId, String paymentMethodId) {
+        PaymentMethodEntity entity = requireOwnedMethod(userId, paymentMethodId);
+        clearDefault(userId);
+        entity.setIsDefault(1);
+        entity.setUpdatedAt(LocalDateTime.now());
+        paymentMethodMapper.updateById(entity);
+        return toMap(entity);
+    }
+
+    public PaymentMethodEntity requireActiveOwnedMethod(String userId, String paymentMethodId) {
+        PaymentMethodEntity entity = requireOwnedMethod(userId, paymentMethodId);
+        if (!DomainConstants.PaymentMethodStatus.ACTIVE.equals(entity.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT, "Payment method is not active");
+        }
+        return entity;
+    }
+
+    public Map<String, Object> toMap(PaymentMethodEntity entity) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("paymentMethodId", entity.getPaymentMethodId());
+        data.put("userId", entity.getUserId());
+        data.put("brand", entity.getBrand());
+        data.put("last4", entity.getLast4());
+        data.put("expiryMonth", entity.getExpiryMonth());
+        data.put("expiryYear", entity.getExpiryYear());
+        data.put("label", entity.getLabel());
+        data.put("isDefault", entity.getIsDefault() != null && entity.getIsDefault() == 1);
+        data.put("status", entity.getStatus());
+        data.put("createdAt", entity.getCreatedAt());
+        data.put("updatedAt", entity.getUpdatedAt());
+        return data;
+    }
+
+    private PaymentMethodEntity requireOwnedMethod(String userId, String paymentMethodId) {
+        PaymentMethodEntity entity = paymentMethodMapper.selectOne(new LambdaQueryWrapper<PaymentMethodEntity>()
+                .eq(PaymentMethodEntity::getPaymentMethodId, paymentMethodId)
+                .eq(PaymentMethodEntity::getUserId, userId));
+        if (entity == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Payment method not found");
+        }
+        return entity;
+    }
+
+    private boolean hasAnyDefault(String userId) {
+        return paymentMethodMapper.selectCount(new LambdaQueryWrapper<PaymentMethodEntity>()
+                .eq(PaymentMethodEntity::getUserId, userId)
+                .eq(PaymentMethodEntity::getIsDefault, 1)
+                .eq(PaymentMethodEntity::getStatus, DomainConstants.PaymentMethodStatus.ACTIVE)) > 0;
+    }
+
+    private void clearDefault(String userId) {
+        List<PaymentMethodEntity> methods = paymentMethodMapper.selectList(new LambdaQueryWrapper<PaymentMethodEntity>()
+                .eq(PaymentMethodEntity::getUserId, userId)
+                .eq(PaymentMethodEntity::getIsDefault, 1));
+        for (PaymentMethodEntity method : methods) {
+            method.setIsDefault(0);
+            method.setUpdatedAt(LocalDateTime.now());
+            paymentMethodMapper.updateById(method);
+        }
+    }
+
+    private String requireText(Object value, String field) {
+        if (value == null || String.valueOf(value).trim().isEmpty()) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        return String.valueOf(value).trim();
+    }
+
+    private Integer requireInteger(Object value, String field) {
+        if (value == null) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (NumberFormatException ex) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR,
+                    field + " must be an integer");
+        }
+    }
+
+    private boolean parseBoolean(Object value) {
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        return Boolean.parseBoolean(String.valueOf(value));
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/PaymentService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/PaymentService.java
@@ -1,0 +1,337 @@
+package com.lcyhz.urbanova.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.lcyhz.urbanova.common.exception.BusinessException;
+import com.lcyhz.urbanova.common.exception.ErrorCodes;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.entity.BookingEntity;
+import com.lcyhz.urbanova.entity.PaymentEntity;
+import com.lcyhz.urbanova.entity.PaymentMethodEntity;
+import com.lcyhz.urbanova.entity.UserEntity;
+import com.lcyhz.urbanova.mapper.BookingMapper;
+import com.lcyhz.urbanova.mapper.PaymentMapper;
+import com.lcyhz.urbanova.mapper.UserMapper;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class PaymentService {
+    private final PaymentMapper paymentMapper;
+    private final BookingMapper bookingMapper;
+    private final PaymentMethodService paymentMethodService;
+    private final PlatformSupportService platformSupportService;
+    private final UserMapper userMapper;
+
+    public PaymentService(PaymentMapper paymentMapper,
+                          BookingMapper bookingMapper,
+                          PaymentMethodService paymentMethodService,
+                          PlatformSupportService platformSupportService,
+                          UserMapper userMapper) {
+        this.paymentMapper = paymentMapper;
+        this.bookingMapper = bookingMapper;
+        this.paymentMethodService = paymentMethodService;
+        this.platformSupportService = platformSupportService;
+        this.userMapper = userMapper;
+    }
+
+    @Transactional(rollbackFor = Exception.class, noRollbackFor = BusinessException.class)
+    public Map<String, Object> createPayment(String userId, String role, String bookingId, Map<String, Object> request) {
+        BookingEntity booking = requireAccessibleBooking(userId, role, bookingId);
+        if (DomainConstants.BookingStatus.CANCELLED.equals(booking.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT, "Cancelled bookings cannot be paid");
+        }
+
+        String method = normalizeMethod(stringValue(request == null ? null : request.get("method")));
+        String paymentMethodId = null;
+        if (DomainConstants.PaymentMethodType.SAVED_CARD.equals(method)) {
+            paymentMethodId = requireText(stringValue(request == null ? null : request.get("paymentMethodId")), "paymentMethodId");
+            PaymentMethodEntity paymentMethod = paymentMethodService.requireActiveOwnedMethod(userId, paymentMethodId);
+            paymentMethodId = paymentMethod.getPaymentMethodId();
+        }
+
+        BigDecimal outstanding = calculateOutstandingAmount(booking.getBookingId(), booking.getPriceFinal());
+        BigDecimal amount = request != null && request.get("amount") != null
+                ? parseBigDecimal(request.get("amount"))
+                : outstanding;
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "amount must be greater than zero");
+        }
+        if (amount.compareTo(outstanding) > 0) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "amount exceeds outstanding balance");
+        }
+
+        PaymentEntity payment = new PaymentEntity();
+        payment.setPaymentId("PAY-" + UUID.randomUUID().toString().replace("-", "").substring(0, 10).toUpperCase(Locale.ROOT));
+        payment.setBookingId(booking.getBookingId());
+        payment.setUserId(booking.getUserId());
+        payment.setAmount(amount.setScale(2, RoundingMode.HALF_UP));
+        payment.setMethod(method);
+        payment.setPaymentMethodId(paymentMethodId);
+        payment.setStatus(DomainConstants.PaymentStatus.INITIATED);
+        payment.setRefundedAmount(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+        payment.setCreatedAt(LocalDateTime.now());
+        payment.setUpdatedAt(LocalDateTime.now());
+        paymentMapper.insert(payment);
+
+        boolean deferSettlement = parseBoolean(request == null ? null : request.get("deferSettlement"));
+        String simulatedOutcome = normalizeOutcome(stringValue(request == null ? null : request.get("simulatedOutcome")));
+        if (!deferSettlement) {
+            applySettlement(payment, booking, simulatedOutcome, role, userId);
+        }
+        return toPaymentMap(paymentMapper.selectOne(new LambdaQueryWrapper<PaymentEntity>()
+                .eq(PaymentEntity::getPaymentId, payment.getPaymentId())));
+    }
+
+    public List<Map<String, Object>> listBookingPayments(String userId, String role, String bookingId) {
+        requireAccessibleBooking(userId, role, bookingId);
+        return paymentMapper.selectList(new LambdaQueryWrapper<PaymentEntity>()
+                        .eq(PaymentEntity::getBookingId, bookingId)
+                        .orderByDesc(PaymentEntity::getCreatedAt))
+                .stream()
+                .map(this::toPaymentMap)
+                .toList();
+    }
+
+    public Map<String, Object> getPaymentDetail(String userId, String role, String paymentId) {
+        PaymentEntity payment = requirePayment(paymentId);
+        requireAccessibleBooking(userId, role, payment.getBookingId());
+        return toPaymentMap(payment);
+    }
+
+    @Transactional(rollbackFor = Exception.class, noRollbackFor = BusinessException.class)
+    public Map<String, Object> simulateSettlement(String paymentId, String outcome, String actorUserId, String actorRole) {
+        PaymentEntity payment = requirePayment(paymentId);
+        if (!DomainConstants.PaymentStatus.INITIATED.equals(payment.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.PAYMENT_FAILED, "Payment is not awaiting settlement");
+        }
+        BookingEntity booking = requireBooking(payment.getBookingId());
+        applySettlement(payment, booking, normalizeOutcome(outcome), actorRole, actorUserId);
+        return toPaymentMap(paymentMapper.selectOne(new LambdaQueryWrapper<PaymentEntity>()
+                .eq(PaymentEntity::getPaymentId, paymentId)));
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> refundPayment(String paymentId, Map<String, Object> request) {
+        PaymentEntity payment = requirePayment(paymentId);
+        if (!DomainConstants.PaymentStatus.SUCCEEDED.equals(payment.getStatus())
+                && !DomainConstants.PaymentStatus.REFUNDED.equals(payment.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.PAYMENT_FAILED, "Only succeeded payments can be refunded");
+        }
+
+        BigDecimal refundable = payment.getAmount().subtract(zeroIfNull(payment.getRefundedAmount()));
+        BigDecimal refundAmount = request != null && request.get("amount") != null
+                ? parseBigDecimal(request.get("amount"))
+                : refundable;
+        if (refundAmount.compareTo(BigDecimal.ZERO) <= 0 || refundAmount.compareTo(refundable) > 0) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "Invalid refund amount");
+        }
+
+        payment.setRefundedAmount(zeroIfNull(payment.getRefundedAmount()).add(refundAmount).setScale(2, RoundingMode.HALF_UP));
+        if (payment.getRefundedAmount().compareTo(payment.getAmount()) >= 0) {
+            payment.setStatus(DomainConstants.PaymentStatus.REFUNDED);
+        }
+        payment.setUpdatedAt(LocalDateTime.now());
+        paymentMapper.updateById(payment);
+
+        BookingEntity booking = requireBooking(payment.getBookingId());
+        BigDecimal outstanding = calculateOutstandingAmount(booking.getBookingId(), booking.getPriceFinal());
+        if (outstanding.compareTo(booking.getPriceFinal()) >= 0) {
+            booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_REFUNDED);
+        } else if (outstanding.compareTo(BigDecimal.ZERO) > 0) {
+            booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_PARTIAL);
+        } else {
+            booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_PAID);
+        }
+        booking.setUpdatedAt(LocalDateTime.now());
+        bookingMapper.updateById(booking);
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "PAYMENT_REFUNDED", null, DomainConstants.ROLE_MANAGER,
+                "Refunded payment " + payment.getPaymentId());
+        platformSupportService.recordAudit("PAYMENT_REFUNDED", "PAYMENT", payment.getPaymentId(), "refundAmount=" + refundAmount);
+        platformSupportService.createNotification(booking.getUserId(), DomainConstants.NotificationType.PAYMENT_UPDATED,
+                "Refund processed", "Refund recorded for booking " + booking.getBookingRef(), booking.getBookingId());
+        return toPaymentMap(payment);
+    }
+
+    private void applySettlement(PaymentEntity payment, BookingEntity booking, String outcome, String actorRole, String actorUserId) {
+        payment.setSimulatedOutcome(outcome);
+        payment.setStatus(DomainConstants.PaymentOutcome.FAILURE.equals(outcome)
+                ? DomainConstants.PaymentStatus.FAILED
+                : DomainConstants.PaymentStatus.SUCCEEDED);
+        payment.setUpdatedAt(LocalDateTime.now());
+        paymentMapper.updateById(payment);
+
+        if (DomainConstants.PaymentStatus.FAILED.equals(payment.getStatus())) {
+            platformSupportService.recordBookingEvent(booking.getBookingId(), "PAYMENT_FAILED", actorUserId, actorRole,
+                    "Payment " + payment.getPaymentId() + " failed");
+            platformSupportService.createNotification(booking.getUserId(), DomainConstants.NotificationType.PAYMENT_UPDATED,
+                    "Payment failed", "Payment failed for booking " + booking.getBookingRef(), booking.getBookingId());
+            throw new BusinessException(HttpStatus.PAYMENT_REQUIRED.value(), ErrorCodes.PAYMENT_FAILED, "Simulated payment failed");
+        }
+
+        BigDecimal outstanding = calculateOutstandingAmount(booking.getBookingId(), booking.getPriceFinal());
+        if (outstanding.compareTo(BigDecimal.ZERO) <= 0) {
+            booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_PAID);
+            if (DomainConstants.BookingStatus.PENDING_PAYMENT.equals(booking.getStatus())) {
+                booking.setStatus(DomainConstants.BookingStatus.CONFIRMED);
+            }
+        } else {
+            booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_PARTIAL);
+        }
+        booking.setUpdatedAt(LocalDateTime.now());
+        bookingMapper.updateById(booking);
+
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "PAYMENT_SUCCEEDED", actorUserId, actorRole,
+                "Payment " + payment.getPaymentId() + " succeeded");
+        platformSupportService.createNotification(booking.getUserId(), DomainConstants.NotificationType.PAYMENT_UPDATED,
+                "Payment received", "Payment recorded for booking " + booking.getBookingRef(), booking.getBookingId());
+
+        if (DomainConstants.PAYMENT_STATUS_PAID.equals(booking.getPaymentStatus())) {
+            String recipientEmail = resolveRecipientEmail(booking);
+            platformSupportService.createOrRefreshConfirmation(
+                    booking,
+                    recipientEmail,
+                    "EMAIL",
+                    "Booking confirmation for " + booking.getBookingRef(),
+                    false);
+            platformSupportService.createNotification(booking.getUserId(), DomainConstants.NotificationType.BOOKING_CONFIRMATION,
+                    "Booking confirmed", "Booking " + booking.getBookingRef() + " is confirmed", booking.getBookingId());
+        }
+    }
+
+    private BookingEntity requireAccessibleBooking(String userId, String role, String bookingId) {
+        BookingEntity booking = requireBooking(bookingId);
+        if (DomainConstants.ROLE_MANAGER.equals(role) || DomainConstants.ROLE_STAFF.equals(role)) {
+            return booking;
+        }
+        if (booking.getUserId() == null || !booking.getUserId().equals(userId)) {
+            throw new BusinessException(HttpStatus.FORBIDDEN.value(), ErrorCodes.AUTH_FORBIDDEN, "No permission for this booking");
+        }
+        return booking;
+    }
+
+    private BookingEntity requireBooking(String bookingId) {
+        BookingEntity booking = bookingMapper.selectOne(new LambdaQueryWrapper<BookingEntity>()
+                .eq(BookingEntity::getBookingId, bookingId));
+        if (booking == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Booking not found");
+        }
+        return booking;
+    }
+
+    private PaymentEntity requirePayment(String paymentId) {
+        PaymentEntity payment = paymentMapper.selectOne(new LambdaQueryWrapper<PaymentEntity>()
+                .eq(PaymentEntity::getPaymentId, paymentId));
+        if (payment == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Payment not found");
+        }
+        return payment;
+    }
+
+    private BigDecimal calculateOutstandingAmount(String bookingId, BigDecimal bookingTotal) {
+        List<PaymentEntity> payments = paymentMapper.selectList(new LambdaQueryWrapper<PaymentEntity>()
+                .eq(PaymentEntity::getBookingId, bookingId));
+        BigDecimal paid = BigDecimal.ZERO;
+        BigDecimal refunded = BigDecimal.ZERO;
+        for (PaymentEntity payment : payments) {
+            if (DomainConstants.PaymentStatus.SUCCEEDED.equals(payment.getStatus())
+                    || DomainConstants.PaymentStatus.REFUNDED.equals(payment.getStatus())) {
+                paid = paid.add(zeroIfNull(payment.getAmount()));
+                refunded = refunded.add(zeroIfNull(payment.getRefundedAmount()));
+            }
+        }
+        return bookingTotal.subtract(paid.subtract(refunded)).max(BigDecimal.ZERO).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private String resolveRecipientEmail(BookingEntity booking) {
+        if (booking.getUserId() != null) {
+            UserEntity user = userMapper.selectOne(new LambdaQueryWrapper<UserEntity>()
+                    .eq(UserEntity::getUserId, booking.getUserId()));
+            if (user != null) {
+                return user.getEmail();
+            }
+        }
+        return booking.getGuestEmail();
+    }
+
+    private String normalizeMethod(String value) {
+        if (value == null || value.isBlank()) {
+            return DomainConstants.PaymentMethodType.ONE_TIME_CARD;
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        if (!List.of(DomainConstants.PaymentMethodType.SAVED_CARD, DomainConstants.PaymentMethodType.ONE_TIME_CARD).contains(normalized)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "method must be SAVED_CARD or ONE_TIME_CARD");
+        }
+        return normalized;
+    }
+
+    private String normalizeOutcome(String value) {
+        if (value == null || value.isBlank()) {
+            return DomainConstants.PaymentOutcome.SUCCESS;
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        if (!List.of(DomainConstants.PaymentOutcome.SUCCESS, DomainConstants.PaymentOutcome.FAILURE).contains(normalized)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "simulatedOutcome must be SUCCESS or FAILURE");
+        }
+        return normalized;
+    }
+
+    private String requireText(String value, String field) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        return value.trim();
+    }
+
+    private String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private boolean parseBoolean(Object value) {
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        return Boolean.parseBoolean(String.valueOf(value));
+    }
+
+    private BigDecimal parseBigDecimal(Object value) {
+        try {
+            return new BigDecimal(String.valueOf(value)).setScale(2, RoundingMode.HALF_UP);
+        } catch (Exception ex) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "Invalid decimal value: " + value);
+        }
+    }
+
+    private BigDecimal zeroIfNull(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+
+    private Map<String, Object> toPaymentMap(PaymentEntity entity) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("paymentId", entity.getPaymentId());
+        data.put("bookingId", entity.getBookingId());
+        data.put("userId", entity.getUserId());
+        data.put("amount", entity.getAmount());
+        data.put("method", entity.getMethod());
+        data.put("paymentMethodId", entity.getPaymentMethodId());
+        data.put("status", entity.getStatus());
+        data.put("simulatedOutcome", entity.getSimulatedOutcome());
+        data.put("refundedAmount", entity.getRefundedAmount());
+        data.put("createdAt", entity.getCreatedAt());
+        data.put("updatedAt", entity.getUpdatedAt());
+        return data;
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/ScooterService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/ScooterService.java
@@ -9,9 +9,16 @@ import com.lcyhz.urbanova.vo.scooter.BulkScooterStatusUpdateVo;
 import com.lcyhz.urbanova.vo.scooter.ScooterMapPointVo;
 import com.lcyhz.urbanova.vo.scooter.ScooterIdsByStatusVo;
 
+import java.util.Map;
 import java.util.List;
 
 public interface ScooterService {
+    List<Map<String, Object>> listPublicScooters(String status, String typeCode, String zone);
+
+    Map<String, Object> getScooterDetail(String scooterId);
+
+    Map<String, Object> getAvailabilitySummary();
+
     ScooterIdsByStatusVo queryScooterIdsByStatus(String status);
 
     List<ScooterMapPointVo> listMapPoints();

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/UserManagementService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/UserManagementService.java
@@ -1,0 +1,228 @@
+package com.lcyhz.urbanova.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.lcyhz.urbanova.common.exception.BusinessException;
+import com.lcyhz.urbanova.common.exception.ErrorCodes;
+import com.lcyhz.urbanova.domain.DomainConstants;
+import com.lcyhz.urbanova.entity.BookingEntity;
+import com.lcyhz.urbanova.entity.PaymentEntity;
+import com.lcyhz.urbanova.entity.UserEntity;
+import com.lcyhz.urbanova.mapper.BookingMapper;
+import com.lcyhz.urbanova.mapper.PaymentMapper;
+import com.lcyhz.urbanova.mapper.UserMapper;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+public class UserManagementService {
+    private final UserMapper userMapper;
+    private final BookingMapper bookingMapper;
+    private final PaymentMapper paymentMapper;
+    private final PlatformSupportService platformSupportService;
+    private final DiscountRuleService discountRuleService;
+
+    public UserManagementService(UserMapper userMapper,
+                                 BookingMapper bookingMapper,
+                                 PaymentMapper paymentMapper,
+                                 PlatformSupportService platformSupportService,
+                                 DiscountRuleService discountRuleService) {
+        this.userMapper = userMapper;
+        this.bookingMapper = bookingMapper;
+        this.paymentMapper = paymentMapper;
+        this.platformSupportService = platformSupportService;
+        this.discountRuleService = discountRuleService;
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> updateCurrentUser(String userId, Map<String, Object> request) {
+        UserEntity user = requireUser(userId);
+        if (request.containsKey("fullName")) {
+            user.setFullName(requireText(request.get("fullName"), "fullName"));
+        }
+        if (request.containsKey("phone")) {
+            user.setPhone(trimToNull((String) request.get("phone")));
+        }
+        if (request.containsKey("discountCategory")) {
+            user.setDiscountCategory(normalizeDiscountCategory((String) request.get("discountCategory")));
+        }
+        user.setUpdatedAt(LocalDateTime.now());
+        userMapper.updateById(user);
+        return toUserMap(user);
+    }
+
+    public Map<String, Object> getUsageSummary(String userId) {
+        requireUser(userId);
+        List<BookingEntity> bookings = bookingMapper.selectList(new LambdaQueryWrapper<BookingEntity>()
+                .eq(BookingEntity::getUserId, userId));
+        List<PaymentEntity> payments = paymentMapper.selectList(new LambdaQueryWrapper<PaymentEntity>()
+                .eq(PaymentEntity::getUserId, userId)
+                .eq(PaymentEntity::getStatus, DomainConstants.PaymentStatus.SUCCEEDED));
+
+        long totalMinutes = 0L;
+        for (BookingEntity booking : bookings) {
+            LocalDateTime start = booking.getActualStartAt() != null ? booking.getActualStartAt() : booking.getStartAt();
+            LocalDateTime end = booking.getActualEndAt() != null ? booking.getActualEndAt() : booking.getEndAt();
+            if (start != null && end != null && !end.isBefore(start)
+                    && !DomainConstants.BookingStatus.CANCELLED.equals(booking.getStatus())) {
+                totalMinutes += Duration.between(start, end).toMinutes();
+            }
+        }
+
+        BigDecimal totalSpent = payments.stream()
+                .map(PaymentEntity::getAmount)
+                .filter(java.util.Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("userId", userId);
+        data.put("bookingCount", bookings.size());
+        data.put("hoursUsed", BigDecimal.valueOf(totalMinutes).divide(BigDecimal.valueOf(60), 2, RoundingMode.HALF_UP));
+        data.put("totalSpent", totalSpent.setScale(2, RoundingMode.HALF_UP));
+        data.put("hoursLast7Days", discountRuleService.calculateRecentHours(userId));
+        data.put("discountEligibility", discountRuleService.getEligibility(userId));
+        return data;
+    }
+
+    public List<Map<String, Object>> listUsers(String role, String accountStatus) {
+        LambdaQueryWrapper<UserEntity> query = new LambdaQueryWrapper<UserEntity>()
+                .orderByAsc(UserEntity::getRole)
+                .orderByAsc(UserEntity::getEmail);
+        if (hasText(role)) {
+            query.eq(UserEntity::getRole, role.trim().toUpperCase(Locale.ROOT));
+        }
+        if (hasText(accountStatus)) {
+            query.eq(UserEntity::getAccountStatus, accountStatus.trim().toUpperCase(Locale.ROOT));
+        }
+        return userMapper.selectList(query).stream().map(this::toUserMap).toList();
+    }
+
+    public Map<String, Object> getUserDetail(String userId) {
+        return toUserMap(requireUser(userId));
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> updateUserStatus(String userId, String accountStatus) {
+        UserEntity user = requireUser(userId);
+        String normalized = normalizeAccountStatus(accountStatus);
+        user.setAccountStatus(normalized);
+        user.setUpdatedAt(LocalDateTime.now());
+        userMapper.updateById(user);
+        platformSupportService.recordAudit("USER_STATUS_UPDATED", "USER", userId, "accountStatus=" + normalized);
+        return toUserMap(user);
+    }
+
+    public List<Map<String, Object>> listUserBookings(String userId) {
+        requireUser(userId);
+        return bookingMapper.selectList(new LambdaQueryWrapper<BookingEntity>()
+                        .eq(BookingEntity::getUserId, userId)
+                        .orderByDesc(BookingEntity::getCreatedAt))
+                .stream()
+                .map(this::toBookingMap)
+                .toList();
+    }
+
+    public List<Map<String, Object>> listAuditLogs(String action, Integer limit) {
+        return platformSupportService.listAuditLogs(action, limit);
+    }
+
+    public Map<String, Object> toUserMap(UserEntity user) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("userId", user.getUserId());
+        data.put("email", user.getEmail());
+        data.put("fullName", user.getFullName());
+        data.put("phone", user.getPhone());
+        data.put("role", user.getRole());
+        data.put("discountCategory", user.getDiscountCategory());
+        data.put("accountStatus", user.getAccountStatus());
+        data.put("createdAt", user.getCreatedAt());
+        data.put("updatedAt", user.getUpdatedAt());
+        return data;
+    }
+
+    public Map<String, Object> toBookingMap(BookingEntity booking) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("bookingId", booking.getBookingId());
+        data.put("bookingRef", booking.getBookingRef());
+        data.put("customerType", booking.getCustomerType());
+        data.put("userId", booking.getUserId());
+        data.put("guestName", booking.getGuestName());
+        data.put("guestEmail", booking.getGuestEmail());
+        data.put("guestPhone", booking.getGuestPhone());
+        data.put("scooterId", booking.getScooterId());
+        data.put("hireOptionId", booking.getHireOptionId());
+        data.put("startAt", booking.getStartAt());
+        data.put("endAt", booking.getEndAt());
+        data.put("actualStartAt", booking.getActualStartAt());
+        data.put("actualEndAt", booking.getActualEndAt());
+        data.put("status", booking.getStatus());
+        data.put("priceBase", booking.getPriceBase());
+        data.put("priceDiscount", booking.getPriceDiscount());
+        data.put("priceFinal", booking.getPriceFinal());
+        data.put("paymentStatus", booking.getPaymentStatus());
+        data.put("createdByRole", booking.getCreatedByRole());
+        data.put("cancelReason", booking.getCancelReason());
+        data.put("createdAt", booking.getCreatedAt());
+        data.put("updatedAt", booking.getUpdatedAt());
+        return data;
+    }
+
+    public UserEntity requireUser(String userId) {
+        UserEntity user = userMapper.selectOne(new LambdaQueryWrapper<UserEntity>()
+                .eq(UserEntity::getUserId, userId));
+        if (user == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "User not found");
+        }
+        return user;
+    }
+
+    private String requireText(Object value, String field) {
+        if (value == null || String.valueOf(value).trim().isEmpty()) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        return String.valueOf(value).trim();
+    }
+
+    private String normalizeDiscountCategory(String value) {
+        if (!hasText(value)) {
+            return DomainConstants.DISCOUNT_NONE;
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        if (!List.of(DomainConstants.DISCOUNT_NONE, DomainConstants.DISCOUNT_STUDENT, DomainConstants.DISCOUNT_SENIOR).contains(normalized)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR,
+                    "discountCategory must be NONE, STUDENT, or SENIOR");
+        }
+        return normalized;
+    }
+
+    private String normalizeAccountStatus(String value) {
+        String normalized = requireText(value, "accountStatus").toUpperCase(Locale.ROOT);
+        if (!List.of(DomainConstants.ACCOUNT_ACTIVE, DomainConstants.ACCOUNT_SUSPENDED, DomainConstants.ACCOUNT_DELETED).contains(normalized)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR,
+                    "accountStatus must be ACTIVE, SUSPENDED, or DELETED");
+        }
+        return normalized;
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/impl/AuthServiceImpl.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/impl/AuthServiceImpl.java
@@ -6,19 +6,27 @@ import com.lcyhz.urbanova.common.exception.ErrorCodes;
 import com.lcyhz.urbanova.domain.DomainConstants;
 import com.lcyhz.urbanova.dto.auth.LoginRequest;
 import com.lcyhz.urbanova.dto.auth.RegisterRequest;
+import com.lcyhz.urbanova.entity.AuthSessionEntity;
+import com.lcyhz.urbanova.entity.PasswordResetTokenEntity;
 import com.lcyhz.urbanova.entity.UserEntity;
+import com.lcyhz.urbanova.mapper.AuthSessionMapper;
+import com.lcyhz.urbanova.mapper.PasswordResetTokenMapper;
 import com.lcyhz.urbanova.mapper.UserMapper;
 import com.lcyhz.urbanova.security.JwtService;
 import com.lcyhz.urbanova.service.AuthService;
 import com.lcyhz.urbanova.vo.auth.AuthPayload;
 import com.lcyhz.urbanova.vo.auth.UserProfileVo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -27,8 +35,14 @@ public class AuthServiceImpl implements AuthService {
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
+    private final AuthSessionMapper authSessionMapper;
+    private final PasswordResetTokenMapper passwordResetTokenMapper;
+
+    @Value("${app.jwt.refresh-expiration-days:14}")
+    private long refreshExpirationDays;
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public AuthPayload register(RegisterRequest request) {
         String normalizedEmail = normalizeEmail(request.getEmail());
         UserEntity existing = userMapper.selectOne(new LambdaQueryWrapper<UserEntity>()
@@ -42,7 +56,7 @@ public class AuthServiceImpl implements AuthService {
         user.setEmail(normalizedEmail);
         user.setPasswordHash(passwordEncoder.encode(request.getPassword()));
         user.setFullName(request.getFullName().trim());
-        user.setPhone(request.getPhone());
+        user.setPhone(trimToNull(request.getPhone()));
         user.setRole(DomainConstants.ROLE_CUSTOMER);
         user.setDiscountCategory(DomainConstants.DISCOUNT_NONE);
         user.setAccountStatus(DomainConstants.ACCOUNT_ACTIVE);
@@ -68,6 +82,113 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
+    public AuthPayload refresh(String refreshToken) {
+        AuthSessionEntity session = requireRefreshSession(refreshToken);
+        UserEntity user = requireActiveUser(session.getUserId());
+
+        session.setRevoked(1);
+        session.setUpdatedAt(LocalDateTime.now());
+        authSessionMapper.updateById(session);
+        return buildAuthPayload(user);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> logout(String userId, String refreshToken) {
+        int revoked = 0;
+        if (refreshToken != null && !refreshToken.isBlank()) {
+            AuthSessionEntity session = authSessionMapper.selectOne(new LambdaQueryWrapper<AuthSessionEntity>()
+                    .eq(AuthSessionEntity::getRefreshToken, refreshToken.trim())
+                    .eq(AuthSessionEntity::getUserId, userId));
+            if (session != null && (session.getRevoked() == null || session.getRevoked() == 0)) {
+                session.setRevoked(1);
+                session.setUpdatedAt(LocalDateTime.now());
+                authSessionMapper.updateById(session);
+                revoked = 1;
+            }
+        } else {
+            for (AuthSessionEntity session : authSessionMapper.selectList(new LambdaQueryWrapper<AuthSessionEntity>()
+                    .eq(AuthSessionEntity::getUserId, userId)
+                    .eq(AuthSessionEntity::getRevoked, 0))) {
+                session.setRevoked(1);
+                session.setUpdatedAt(LocalDateTime.now());
+                authSessionMapper.updateById(session);
+                revoked++;
+            }
+        }
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("userId", userId);
+        data.put("revokedSessions", revoked);
+        data.put("loggedOut", true);
+        return data;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> forgotPassword(String email) {
+        String normalizedEmail = normalizeEmail(email);
+        UserEntity user = userMapper.selectOne(new LambdaQueryWrapper<UserEntity>()
+                .eq(UserEntity::getEmail, normalizedEmail));
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("accepted", true);
+        data.put("email", normalizedEmail);
+        if (user == null) {
+            data.put("resetToken", null);
+            return data;
+        }
+
+        PasswordResetTokenEntity token = new PasswordResetTokenEntity();
+        token.setResetTokenId("RST-" + UUID.randomUUID().toString().replace("-", "").substring(0, 10).toUpperCase(Locale.ROOT));
+        token.setUserId(user.getUserId());
+        token.setResetToken(UUID.randomUUID().toString().replace("-", "") + UUID.randomUUID().toString().replace("-", ""));
+        token.setExpiresAt(LocalDateTime.now().plusHours(1));
+        token.setUsed(0);
+        token.setCreatedAt(LocalDateTime.now());
+        token.setUpdatedAt(LocalDateTime.now());
+        passwordResetTokenMapper.insert(token);
+
+        data.put("resetToken", token.getResetToken());
+        data.put("expiresAt", token.getExpiresAt());
+        return data;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> resetPassword(String resetToken, String newPassword) {
+        PasswordResetTokenEntity token = passwordResetTokenMapper.selectOne(new LambdaQueryWrapper<PasswordResetTokenEntity>()
+                .eq(PasswordResetTokenEntity::getResetToken, resetToken)
+                .eq(PasswordResetTokenEntity::getUsed, 0));
+        if (token == null || token.getExpiresAt() == null || token.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.AUTH_INVALID_CREDENTIALS, "Reset token is invalid or expired");
+        }
+
+        UserEntity user = requireActiveUser(token.getUserId());
+        user.setPasswordHash(passwordEncoder.encode(newPassword));
+        user.setUpdatedAt(LocalDateTime.now());
+        userMapper.updateById(user);
+
+        token.setUsed(1);
+        token.setUpdatedAt(LocalDateTime.now());
+        passwordResetTokenMapper.updateById(token);
+
+        for (AuthSessionEntity session : authSessionMapper.selectList(new LambdaQueryWrapper<AuthSessionEntity>()
+                .eq(AuthSessionEntity::getUserId, user.getUserId())
+                .eq(AuthSessionEntity::getRevoked, 0))) {
+            session.setRevoked(1);
+            session.setUpdatedAt(LocalDateTime.now());
+            authSessionMapper.updateById(session);
+        }
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("userId", user.getUserId());
+        data.put("passwordReset", true);
+        return data;
+    }
+
+    @Override
     public UserProfileVo getCurrentUser(String userId) {
         UserEntity user = userMapper.selectOne(new LambdaQueryWrapper<UserEntity>()
                 .eq(UserEntity::getUserId, userId));
@@ -78,13 +199,55 @@ public class AuthServiceImpl implements AuthService {
     }
 
     private AuthPayload buildAuthPayload(UserEntity user) {
+        AuthSessionEntity session = createSession(user.getUserId());
         String accessToken = jwtService.generateToken(user.getUserId(), user.getRole(), user.getEmail());
         AuthPayload payload = new AuthPayload();
+        payload.setSessionId(session.getSessionId());
         payload.setAccessToken(accessToken);
+        payload.setRefreshToken(session.getRefreshToken());
         payload.setTokenType("Bearer");
         payload.setExpiresInSeconds(jwtService.getExpirationSeconds());
+        payload.setRefreshExpiresInSeconds(refreshExpirationDays * 24 * 60 * 60);
         payload.setUser(toUserProfile(user));
         return payload;
+    }
+
+    private AuthSessionEntity createSession(String userId) {
+        AuthSessionEntity session = new AuthSessionEntity();
+        session.setSessionId("SES-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12).toUpperCase(Locale.ROOT));
+        session.setUserId(userId);
+        session.setRefreshToken(UUID.randomUUID().toString().replace("-", "") + UUID.randomUUID().toString().replace("-", ""));
+        session.setExpiresAt(LocalDateTime.now().plusDays(refreshExpirationDays));
+        session.setRevoked(0);
+        session.setCreatedAt(LocalDateTime.now());
+        session.setUpdatedAt(LocalDateTime.now());
+        authSessionMapper.insert(session);
+        return session;
+    }
+
+    private AuthSessionEntity requireRefreshSession(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "refreshToken is required");
+        }
+        AuthSessionEntity session = authSessionMapper.selectOne(new LambdaQueryWrapper<AuthSessionEntity>()
+                .eq(AuthSessionEntity::getRefreshToken, refreshToken.trim())
+                .eq(AuthSessionEntity::getRevoked, 0));
+        if (session == null || session.getExpiresAt() == null || session.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED.value(), ErrorCodes.AUTH_INVALID_CREDENTIALS, "Refresh token is invalid or expired");
+        }
+        return session;
+    }
+
+    private UserEntity requireActiveUser(String userId) {
+        UserEntity user = userMapper.selectOne(new LambdaQueryWrapper<UserEntity>()
+                .eq(UserEntity::getUserId, userId));
+        if (user == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "User not found");
+        }
+        if (!DomainConstants.ACCOUNT_ACTIVE.equals(user.getAccountStatus())) {
+            throw new BusinessException(HttpStatus.FORBIDDEN.value(), ErrorCodes.AUTH_FORBIDDEN, "Account is not active");
+        }
+        return user;
     }
 
     private UserProfileVo toUserProfile(UserEntity user) {
@@ -103,5 +266,12 @@ public class AuthServiceImpl implements AuthService {
     private String normalizeEmail(String email) {
         return email == null ? null : email.trim().toLowerCase(Locale.ROOT);
     }
-}
 
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/impl/BookingServiceImpl.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/impl/BookingServiceImpl.java
@@ -8,13 +8,19 @@ import com.lcyhz.urbanova.domain.DomainConstants;
 import com.lcyhz.urbanova.dto.booking.CancelBookingRequest;
 import com.lcyhz.urbanova.dto.booking.CreateBookingRequest;
 import com.lcyhz.urbanova.dto.booking.UpdateBookingRequest;
+import com.lcyhz.urbanova.entity.BookingConfirmationEntity;
 import com.lcyhz.urbanova.entity.BookingEntity;
 import com.lcyhz.urbanova.entity.HireOptionEntity;
+import com.lcyhz.urbanova.entity.PaymentEntity;
 import com.lcyhz.urbanova.entity.ScooterEntity;
+import com.lcyhz.urbanova.mapper.BookingConfirmationMapper;
 import com.lcyhz.urbanova.mapper.BookingMapper;
 import com.lcyhz.urbanova.mapper.HireOptionMapper;
+import com.lcyhz.urbanova.mapper.PaymentMapper;
 import com.lcyhz.urbanova.mapper.ScooterMapper;
 import com.lcyhz.urbanova.service.BookingService;
+import com.lcyhz.urbanova.service.DiscountRuleService;
+import com.lcyhz.urbanova.service.support.PlatformSupportService;
 import com.lcyhz.urbanova.vo.booking.BookingDetailVo;
 import com.lcyhz.urbanova.vo.booking.BookingListItemVo;
 import com.lcyhz.urbanova.vo.booking.CancelBookingVo;
@@ -27,74 +33,57 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class BookingServiceImpl implements BookingService {
-    private static final Set<String> QUERYABLE_STATUSES = Set.of(
-            DomainConstants.BookingStatus.CONFIRMED,
-            DomainConstants.BookingStatus.CANCELLED
+    private static final Set<String> CUSTOMER_MUTABLE_STATUSES = Set.of(
+            DomainConstants.BookingStatus.PENDING_PAYMENT,
+            DomainConstants.BookingStatus.CONFIRMED
     );
 
     private final BookingMapper bookingMapper;
     private final HireOptionMapper hireOptionMapper;
     private final ScooterMapper scooterMapper;
+    private final PaymentMapper paymentMapper;
+    private final BookingConfirmationMapper bookingConfirmationMapper;
+    private final DiscountRuleService discountRuleService;
+    private final PlatformSupportService platformSupportService;
 
     @Override
     @Transactional(rollbackFor = Exception.class)
     public CreateBookingVo createBooking(String userId, CreateBookingRequest request) {
         HireOptionEntity hireOption = findHireOption(request.getHireOptionId());
-
-        ScooterEntity scooter = scooterMapper.selectOne(new LambdaQueryWrapper<ScooterEntity>()
-                .eq(ScooterEntity::getScooterId, request.getScooterId()));
-        if (scooter == null) {
-            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Scooter not found");
-        }
-        if (!DomainConstants.ScooterStatus.AVAILABLE.equals(scooter.getStatus())) {
-            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.SCOOTER_NOT_AVAILABLE, "Scooter is no longer available");
-        }
-
+        ScooterEntity scooter = requireAvailableScooter(request.getScooterId());
         LocalDateTime startAt = request.getPlannedStartAt() == null ? LocalDateTime.now() : request.getPlannedStartAt();
-        LocalDateTime endAt = startAt.plusMinutes(hireOption.getDurationMinutes());
-        BigDecimal basePrice = hireOption.getBasePrice();
+        PriceSnapshot priceSnapshot = calculatePrice(userId, hireOption.getBasePrice());
 
-        UpdateWrapper<ScooterEntity> reserveUpdate = new UpdateWrapper<>();
-        reserveUpdate.eq("scooter_id", scooter.getScooterId())
-                .eq("status", DomainConstants.ScooterStatus.AVAILABLE)
-                .set("status", DomainConstants.ScooterStatus.RESERVED)
-                .set("updated_at", LocalDateTime.now())
-                .setSql("version = version + 1");
-        int reserveRows = scooterMapper.update(null, reserveUpdate);
-        if (reserveRows == 0) {
-            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.SCOOTER_NOT_AVAILABLE, "Scooter is no longer available");
-        }
-
-        BookingEntity booking = new BookingEntity();
-        booking.setBookingId(newBookingId());
-        booking.setBookingRef(newBookingRef());
-        booking.setCustomerType(DomainConstants.CUSTOMER_TYPE_REGISTERED);
-        booking.setUserId(userId);
-        booking.setScooterId(scooter.getScooterId());
-        booking.setHireOptionId(hireOption.getHireOptionId());
-        booking.setStartAt(startAt);
-        booking.setEndAt(endAt);
-        booking.setStatus(DomainConstants.BookingStatus.CONFIRMED);
-        booking.setPriceBase(basePrice);
-        booking.setPriceDiscount(BigDecimal.ZERO);
-        booking.setPriceFinal(basePrice);
-        booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_UNPAID);
-        booking.setCreatedByRole(DomainConstants.ROLE_CUSTOMER);
-        booking.setCreatedAt(LocalDateTime.now());
-        booking.setUpdatedAt(LocalDateTime.now());
+        reserveScooter(scooter.getScooterId());
+        BookingEntity booking = createBookingEntity(
+                DomainConstants.CUSTOMER_TYPE_REGISTERED,
+                userId,
+                null,
+                null,
+                null,
+                scooter.getScooterId(),
+                hireOption,
+                startAt,
+                priceSnapshot,
+                DomainConstants.ROLE_CUSTOMER);
         bookingMapper.insert(booking);
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "BOOKING_CREATED", userId, DomainConstants.ROLE_CUSTOMER,
+                "Initial booking created and awaiting payment");
 
         CreateBookingVo response = new CreateBookingVo();
         response.setBookingId(booking.getBookingId());
         response.setStatus(booking.getStatus());
+        response.setPaymentStatus(booking.getPaymentStatus());
         response.setScooterStatusSnapshot(DomainConstants.ScooterStatus.RESERVED);
         response.setStartAt(booking.getStartAt());
         response.setEndAt(booking.getEndAt());
@@ -107,23 +96,15 @@ public class BookingServiceImpl implements BookingService {
         LambdaQueryWrapper<BookingEntity> query = new LambdaQueryWrapper<BookingEntity>()
                 .eq(BookingEntity::getUserId, userId)
                 .orderByDesc(BookingEntity::getUpdatedAt);
-
         if (hasText(status)) {
-            String normalizedStatus = status.trim().toUpperCase(Locale.ROOT);
-            if (!QUERYABLE_STATUSES.contains(normalizedStatus)) {
-                throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR,
-                        "status must be CONFIRMED or CANCELLED");
-            }
-            query.eq(BookingEntity::getStatus, normalizedStatus);
+            query.eq(BookingEntity::getStatus, status.trim().toUpperCase(Locale.ROOT));
         }
-
         return bookingMapper.selectList(query).stream().map(this::toListItemVo).toList();
     }
 
     @Override
     public BookingDetailVo getBookingDetail(String userId, String bookingId) {
-        BookingEntity booking = findOwnedBooking(userId, bookingId);
-        return toDetailVo(booking);
+        return toDetailVo(requireAccessibleBooking(userId, DomainConstants.ROLE_CUSTOMER, bookingId));
     }
 
     @Override
@@ -134,8 +115,8 @@ public class BookingServiceImpl implements BookingService {
                     "At least one field is required: scooterId, hireOptionId, plannedStartAt");
         }
 
-        BookingEntity booking = findOwnedBooking(userId, bookingId);
-        if (!DomainConstants.BookingStatus.CONFIRMED.equals(booking.getStatus())) {
+        BookingEntity booking = requireAccessibleBooking(userId, DomainConstants.ROLE_CUSTOMER, bookingId);
+        if (!CUSTOMER_MUTABLE_STATUSES.contains(booking.getStatus())) {
             throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT,
                     "Booking cannot be modified in current state");
         }
@@ -144,12 +125,11 @@ public class BookingServiceImpl implements BookingService {
                 ? findHireOption(request.getHireOptionId())
                 : findHireOptionByStoredId(booking.getHireOptionId());
         LocalDateTime startAt = request.getPlannedStartAt() == null ? booking.getStartAt() : request.getPlannedStartAt();
-        LocalDateTime endAt = startAt.plusMinutes(hireOption.getDurationMinutes());
-        BigDecimal basePrice = hireOption.getBasePrice();
+        PriceSnapshot priceSnapshot = calculatePrice(booking.getUserId(), hireOption.getBasePrice());
 
         String scooterId = booking.getScooterId();
         if (hasText(request.getScooterId())) {
-            String requestedScooterId = request.getScooterId().trim();
+            String requestedScooterId = normalizeScooterId(request.getScooterId());
             if (!requestedScooterId.equals(booking.getScooterId())) {
                 reserveScooter(requestedScooterId);
                 releaseScooter(booking.getScooterId());
@@ -157,32 +137,26 @@ public class BookingServiceImpl implements BookingService {
             }
         }
 
-        UpdateWrapper<BookingEntity> update = new UpdateWrapper<>();
-        update.eq("booking_id", bookingId)
-                .eq("user_id", userId)
-                .eq("status", DomainConstants.BookingStatus.CONFIRMED)
-                .set("scooter_id", scooterId)
-                .set("hire_option_id", hireOption.getHireOptionId())
-                .set("start_at", startAt)
-                .set("end_at", endAt)
-                .set("price_base", basePrice)
-                .set("price_discount", BigDecimal.ZERO)
-                .set("price_final", basePrice)
-                .set("updated_at", LocalDateTime.now());
-        int updateRows = bookingMapper.update(null, update);
-        if (updateRows == 0) {
-            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT,
-                    "Booking state changed, please retry");
-        }
-
-        return getBookingDetail(userId, bookingId);
+        booking.setScooterId(scooterId);
+        booking.setHireOptionId(hireOption.getHireOptionId());
+        booking.setStartAt(startAt);
+        booking.setEndAt(startAt.plusMinutes(hireOption.getDurationMinutes()));
+        booking.setPriceBase(hireOption.getBasePrice());
+        booking.setPriceDiscount(priceSnapshot.discount());
+        booking.setPriceFinal(priceSnapshot.finalPrice());
+        booking.setStatus(DomainConstants.BookingStatus.PENDING_PAYMENT);
+        booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_UNPAID);
+        booking.setUpdatedAt(LocalDateTime.now());
+        bookingMapper.updateById(booking);
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "BOOKING_UPDATED", userId, DomainConstants.ROLE_CUSTOMER,
+                "Booking details updated and payment needs reconfirmation");
+        return toDetailVo(booking);
     }
 
     @Override
     @Transactional(rollbackFor = Exception.class)
     public CancelBookingVo cancelBooking(String userId, String bookingId, CancelBookingRequest request) {
-        BookingEntity booking = findOwnedBooking(userId, bookingId);
-
+        BookingEntity booking = requireAccessibleBooking(userId, DomainConstants.ROLE_CUSTOMER, bookingId);
         if (DomainConstants.BookingStatus.CANCELLED.equals(booking.getStatus())) {
             CancelBookingVo alreadyCancelled = new CancelBookingVo();
             alreadyCancelled.setBookingId(booking.getBookingId());
@@ -191,28 +165,19 @@ public class BookingServiceImpl implements BookingService {
             return alreadyCancelled;
         }
 
-        if (!DomainConstants.BookingStatus.CONFIRMED.equals(booking.getStatus())) {
+        if (!Set.of(DomainConstants.BookingStatus.PENDING_PAYMENT, DomainConstants.BookingStatus.CONFIRMED).contains(booking.getStatus())) {
             throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT, "Booking cannot be cancelled in current state");
         }
 
-        UpdateWrapper<BookingEntity> cancelUpdate = new UpdateWrapper<>();
-        cancelUpdate.eq("booking_id", bookingId)
-                .eq("status", DomainConstants.BookingStatus.CONFIRMED)
-                .set("status", DomainConstants.BookingStatus.CANCELLED)
-                .set("cancel_reason", request == null ? null : request.getReason())
-                .set("updated_at", LocalDateTime.now());
-        int cancelRows = bookingMapper.update(null, cancelUpdate);
-        if (cancelRows == 0) {
-            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT, "Booking state changed, please retry");
-        }
-
-        UpdateWrapper<ScooterEntity> releaseUpdate = new UpdateWrapper<>();
-        releaseUpdate.eq("scooter_id", booking.getScooterId())
-                .eq("status", DomainConstants.ScooterStatus.RESERVED)
-                .set("status", DomainConstants.ScooterStatus.AVAILABLE)
-                .set("updated_at", LocalDateTime.now())
-                .setSql("version = version + 1");
-        scooterMapper.update(null, releaseUpdate);
+        booking.setStatus(DomainConstants.BookingStatus.CANCELLED);
+        booking.setCancelReason(request == null ? null : request.getReason());
+        booking.setUpdatedAt(LocalDateTime.now());
+        bookingMapper.updateById(booking);
+        releaseScooter(booking.getScooterId());
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "BOOKING_CANCELLED", userId, DomainConstants.ROLE_CUSTOMER,
+                booking.getCancelReason());
+        platformSupportService.createNotification(booking.getUserId(), DomainConstants.NotificationType.BOOKING_CANCELLED,
+                "Booking cancelled", "Booking " + booking.getBookingRef() + " was cancelled", booking.getBookingId());
 
         CancelBookingVo response = new CancelBookingVo();
         response.setBookingId(booking.getBookingId());
@@ -221,7 +186,269 @@ public class BookingServiceImpl implements BookingService {
         return response;
     }
 
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> startBooking(String userId, String role, String bookingId) {
+        BookingEntity booking = requireAccessibleBooking(userId, role, bookingId);
+        if (!DomainConstants.BookingStatus.CONFIRMED.equals(booking.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT, "Booking cannot be started in current state");
+        }
+        booking.setStatus(DomainConstants.BookingStatus.ACTIVE);
+        booking.setActualStartAt(LocalDateTime.now());
+        booking.setUpdatedAt(LocalDateTime.now());
+        bookingMapper.updateById(booking);
+        setScooterStatus(booking.getScooterId(), DomainConstants.ScooterStatus.IN_USE);
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "BOOKING_STARTED", userId, role, "Ride started");
+        return toBookingMap(booking);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> endBooking(String userId, String role, String bookingId) {
+        BookingEntity booking = requireAccessibleBooking(userId, role, bookingId);
+        if (!DomainConstants.BookingStatus.ACTIVE.equals(booking.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT, "Booking cannot be ended in current state");
+        }
+        booking.setStatus(DomainConstants.BookingStatus.COMPLETED);
+        booking.setActualEndAt(LocalDateTime.now());
+        booking.setUpdatedAt(LocalDateTime.now());
+        bookingMapper.updateById(booking);
+        setScooterStatus(booking.getScooterId(), DomainConstants.ScooterStatus.AVAILABLE);
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "BOOKING_COMPLETED", userId, role, "Ride ended");
+        return toBookingMap(booking);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> extendBooking(String userId, String role, String bookingId, Map<String, Object> request) {
+        BookingEntity booking = requireAccessibleBooking(userId, role, bookingId);
+        if (!Set.of(DomainConstants.BookingStatus.CONFIRMED, DomainConstants.BookingStatus.ACTIVE).contains(booking.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.BOOKING_CONFLICT, "Booking cannot be extended in current state");
+        }
+
+        String additionalHireOption = request == null ? null : stringValue(request.get("additionalHireOptionCode"));
+        if (!hasText(additionalHireOption)) {
+            additionalHireOption = request == null ? null : stringValue(request.get("additionalHireOptionId"));
+        }
+        HireOptionEntity extensionOption = findHireOption(additionalHireOption);
+        PriceSnapshot extensionPrice = calculatePrice(booking.getUserId(), extensionOption.getBasePrice());
+
+        LocalDateTime oldEndAt = booking.getEndAt();
+        booking.setEndAt(booking.getEndAt().plusMinutes(extensionOption.getDurationMinutes()));
+        booking.setPriceBase(booking.getPriceBase().add(extensionOption.getBasePrice()));
+        booking.setPriceDiscount(booking.getPriceDiscount().add(extensionPrice.discount()));
+        booking.setPriceFinal(booking.getPriceFinal().add(extensionPrice.finalPrice()));
+        if (DomainConstants.PAYMENT_STATUS_PAID.equals(booking.getPaymentStatus())) {
+            booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_PARTIAL);
+        }
+        booking.setUpdatedAt(LocalDateTime.now());
+        bookingMapper.updateById(booking);
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "BOOKING_EXTENDED", userId, role,
+                "Extended by " + extensionOption.getCode());
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("bookingId", booking.getBookingId());
+        data.put("oldEndAt", oldEndAt);
+        data.put("newEndAt", booking.getEndAt());
+        data.put("additionalCharge", extensionPrice.finalPrice());
+        data.put("paymentStatus", booking.getPaymentStatus());
+        return data;
+    }
+
+    @Override
+    public List<Map<String, Object>> getBookingTimeline(String userId, String role, String bookingId) {
+        requireAccessibleBooking(userId, role, bookingId);
+        return platformSupportService.listBookingTimeline(bookingId);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> createGuestBooking(String staffUserId, Map<String, Object> request) {
+        HireOptionEntity hireOption = findHireOption(stringValue(request.get("hireOptionId")));
+        ScooterEntity scooter = requireAvailableScooter(stringValue(request.get("scooterId")));
+        LocalDateTime startAt = request != null && request.get("plannedStartAt") != null
+                ? LocalDateTime.parse(String.valueOf(request.get("plannedStartAt")))
+                : LocalDateTime.now();
+
+        reserveScooter(scooter.getScooterId());
+        BookingEntity booking = createBookingEntity(
+                DomainConstants.CUSTOMER_TYPE_GUEST,
+                null,
+                requireText(request.get("guestName"), "guestName"),
+                requireText(request.get("guestEmail"), "guestEmail"),
+                stringValue(request.get("guestPhone")),
+                scooter.getScooterId(),
+                hireOption,
+                startAt,
+                new PriceSnapshot(hireOption.getBasePrice(), BigDecimal.ZERO, hireOption.getBasePrice()),
+                DomainConstants.ROLE_STAFF);
+        bookingMapper.insert(booking);
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "BOOKING_CREATED", staffUserId, DomainConstants.ROLE_STAFF,
+                "Guest booking created");
+        return toBookingMap(booking);
+    }
+
+    @Override
+    public Map<String, Object> getGuestBookingDetail(String staffUserId, String bookingId) {
+        BookingEntity booking = requireBooking(bookingId);
+        if (!DomainConstants.CUSTOMER_TYPE_GUEST.equals(booking.getCustomerType())) {
+            throw new BusinessException(HttpStatus.FORBIDDEN.value(), ErrorCodes.AUTH_FORBIDDEN, "Not a guest booking");
+        }
+        return toBookingMap(booking);
+    }
+
+    @Override
+    public List<Map<String, Object>> listAdminBookings(String status, String paymentStatus, String customerType) {
+        LambdaQueryWrapper<BookingEntity> query = new LambdaQueryWrapper<BookingEntity>()
+                .orderByDesc(BookingEntity::getCreatedAt);
+        if (hasText(status)) {
+            query.eq(BookingEntity::getStatus, status.trim().toUpperCase(Locale.ROOT));
+        }
+        if (hasText(paymentStatus)) {
+            query.eq(BookingEntity::getPaymentStatus, paymentStatus.trim().toUpperCase(Locale.ROOT));
+        }
+        if (hasText(customerType)) {
+            query.eq(BookingEntity::getCustomerType, customerType.trim().toUpperCase(Locale.ROOT));
+        }
+        return bookingMapper.selectList(query).stream().map(this::toBookingMap).toList();
+    }
+
+    @Override
+    public Map<String, Object> getAdminBookingDetail(String bookingId) {
+        BookingEntity booking = requireBooking(bookingId);
+        Map<String, Object> data = toBookingMap(booking);
+        data.put("timeline", platformSupportService.listBookingTimeline(bookingId));
+        data.put("payments", paymentMapper.selectList(new LambdaQueryWrapper<PaymentEntity>()
+                .eq(PaymentEntity::getBookingId, bookingId)
+                .orderByDesc(PaymentEntity::getCreatedAt)).stream().map(this::toPaymentMap).toList());
+        return data;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> overrideBooking(String bookingId, Map<String, Object> request) {
+        BookingEntity booking = requireBooking(bookingId);
+        if (request.containsKey("scooterId")) {
+            String newScooterId = normalizeScooterId(stringValue(request.get("scooterId")));
+            if (!newScooterId.equals(booking.getScooterId())) {
+                reserveScooter(newScooterId);
+                releaseScooter(booking.getScooterId());
+                booking.setScooterId(newScooterId);
+            }
+        }
+        if (request.containsKey("status")) {
+            String status = normalizeBookingStatus(stringValue(request.get("status")));
+            booking.setStatus(status);
+            if (DomainConstants.BookingStatus.CANCELLED.equals(status)) {
+                releaseScooter(booking.getScooterId());
+            }
+            if (DomainConstants.BookingStatus.ACTIVE.equals(status)) {
+                setScooterStatus(booking.getScooterId(), DomainConstants.ScooterStatus.IN_USE);
+                if (booking.getActualStartAt() == null) {
+                    booking.setActualStartAt(LocalDateTime.now());
+                }
+            }
+            if (DomainConstants.BookingStatus.COMPLETED.equals(status)) {
+                setScooterStatus(booking.getScooterId(), DomainConstants.ScooterStatus.AVAILABLE);
+                if (booking.getActualEndAt() == null) {
+                    booking.setActualEndAt(LocalDateTime.now());
+                }
+            }
+        }
+        if (request.containsKey("paymentStatus")) {
+            booking.setPaymentStatus(normalizePaymentStatus(stringValue(request.get("paymentStatus"))));
+        }
+        if (request.containsKey("cancelReason")) {
+            booking.setCancelReason(stringValue(request.get("cancelReason")));
+        }
+        booking.setUpdatedAt(LocalDateTime.now());
+        bookingMapper.updateById(booking);
+        platformSupportService.recordBookingEvent(booking.getBookingId(), "BOOKING_OVERRIDDEN", null, DomainConstants.ROLE_MANAGER,
+                "Manager override applied");
+        platformSupportService.recordAudit("BOOKING_OVERRIDDEN", "BOOKING", bookingId, "Manager override applied");
+        return getAdminBookingDetail(bookingId);
+    }
+
+    @Override
+    public Map<String, Object> getBookingConfirmation(String userId, String role, String bookingId) {
+        BookingEntity booking = requireAccessibleBooking(userId, role, bookingId);
+        BookingConfirmationEntity confirmation = bookingConfirmationMapper.selectOne(new LambdaQueryWrapper<BookingConfirmationEntity>()
+                .eq(BookingConfirmationEntity::getBookingId, booking.getBookingId())
+                .orderByDesc(BookingConfirmationEntity::getUpdatedAt)
+                .last("LIMIT 1"));
+        return platformSupportService.toConfirmationMap(confirmation);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public Map<String, Object> resendBookingConfirmation(String userId, String role, String bookingId) {
+        BookingEntity booking = requireAccessibleBooking(userId, role, bookingId);
+        String recipientEmail = resolveConfirmationRecipient(booking);
+        BookingConfirmationEntity confirmation = platformSupportService.createOrRefreshConfirmation(
+                booking,
+                recipientEmail,
+                "EMAIL",
+                "Booking confirmation for " + booking.getBookingRef(),
+                true);
+        if (booking.getUserId() != null) {
+            platformSupportService.createNotification(booking.getUserId(), DomainConstants.NotificationType.BOOKING_CONFIRMATION,
+                    "Booking confirmation resent", "Confirmation resent for booking " + booking.getBookingRef(), booking.getBookingId());
+        }
+        return platformSupportService.toConfirmationMap(confirmation);
+    }
+
+    @Override
+    public List<Map<String, Object>> listConfirmations(String userId) {
+        return bookingConfirmationMapper.selectList(new LambdaQueryWrapper<BookingConfirmationEntity>()
+                        .eq(BookingConfirmationEntity::getUserId, userId)
+                        .orderByDesc(BookingConfirmationEntity::getUpdatedAt))
+                .stream()
+                .map(platformSupportService::toConfirmationMap)
+                .toList();
+    }
+
+    private BookingEntity createBookingEntity(String customerType,
+                                              String userId,
+                                              String guestName,
+                                              String guestEmail,
+                                              String guestPhone,
+                                              String scooterId,
+                                              HireOptionEntity hireOption,
+                                              LocalDateTime startAt,
+                                              PriceSnapshot priceSnapshot,
+                                              String createdByRole) {
+        BookingEntity booking = new BookingEntity();
+        booking.setBookingId(newBookingId());
+        booking.setBookingRef(newBookingRef());
+        booking.setCustomerType(customerType);
+        booking.setUserId(userId);
+        booking.setGuestName(trimToNull(guestName));
+        booking.setGuestEmail(trimToNull(guestEmail));
+        booking.setGuestPhone(trimToNull(guestPhone));
+        booking.setScooterId(scooterId);
+        booking.setHireOptionId(hireOption.getHireOptionId());
+        booking.setStartAt(startAt);
+        booking.setEndAt(startAt.plusMinutes(hireOption.getDurationMinutes()));
+        booking.setStatus(DomainConstants.BookingStatus.PENDING_PAYMENT);
+        booking.setPriceBase(hireOption.getBasePrice());
+        booking.setPriceDiscount(priceSnapshot.discount());
+        booking.setPriceFinal(priceSnapshot.finalPrice());
+        booking.setPaymentStatus(DomainConstants.PAYMENT_STATUS_UNPAID);
+        booking.setCreatedByRole(createdByRole);
+        booking.setCreatedAt(LocalDateTime.now());
+        booking.setUpdatedAt(LocalDateTime.now());
+        return booking;
+    }
+
+    private PriceSnapshot calculatePrice(String userId, BigDecimal basePrice) {
+        DiscountRuleService.DiscountComputation computation = discountRuleService.calculateForUser(userId, basePrice);
+        return new PriceSnapshot(basePrice, computation.totalDiscount(), computation.finalPrice());
+    }
+
     private HireOptionEntity findHireOption(String input) {
+        if (!hasText(input)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "hireOptionId is required");
+        }
         HireOptionEntity hireOption = hireOptionMapper.selectOne(new LambdaQueryWrapper<HireOptionEntity>()
                 .eq(HireOptionEntity::getActive, 1)
                 .and(wrapper -> wrapper.eq(HireOptionEntity::getHireOptionId, input)
@@ -243,11 +470,10 @@ public class BookingServiceImpl implements BookingService {
         return hireOption;
     }
 
-    private BookingEntity findOwnedBooking(String userId, String bookingId) {
-        BookingEntity booking = bookingMapper.selectOne(new LambdaQueryWrapper<BookingEntity>()
-                .eq(BookingEntity::getBookingId, bookingId));
-        if (booking == null) {
-            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Booking not found");
+    private BookingEntity requireAccessibleBooking(String userId, String role, String bookingId) {
+        BookingEntity booking = requireBooking(bookingId);
+        if (DomainConstants.ROLE_MANAGER.equals(role) || DomainConstants.ROLE_STAFF.equals(role)) {
+            return booking;
         }
         if (!userId.equals(booking.getUserId())) {
             throw new BusinessException(HttpStatus.FORBIDDEN.value(), ErrorCodes.AUTH_FORBIDDEN, "No permission for this booking");
@@ -255,18 +481,30 @@ public class BookingServiceImpl implements BookingService {
         return booking;
     }
 
-    private void reserveScooter(String scooterId) {
+    private BookingEntity requireBooking(String bookingId) {
+        BookingEntity booking = bookingMapper.selectOne(new LambdaQueryWrapper<BookingEntity>()
+                .eq(BookingEntity::getBookingId, bookingId));
+        if (booking == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Booking not found");
+        }
+        return booking;
+    }
+
+    private ScooterEntity requireAvailableScooter(String scooterId) {
         ScooterEntity scooter = scooterMapper.selectOne(new LambdaQueryWrapper<ScooterEntity>()
-                .eq(ScooterEntity::getScooterId, scooterId));
+                .eq(ScooterEntity::getScooterId, normalizeScooterId(scooterId)));
         if (scooter == null) {
             throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Scooter not found");
         }
         if (!DomainConstants.ScooterStatus.AVAILABLE.equals(scooter.getStatus())) {
             throw new BusinessException(HttpStatus.CONFLICT.value(), ErrorCodes.SCOOTER_NOT_AVAILABLE, "Scooter is no longer available");
         }
+        return scooter;
+    }
 
+    private void reserveScooter(String scooterId) {
         UpdateWrapper<ScooterEntity> reserveUpdate = new UpdateWrapper<>();
-        reserveUpdate.eq("scooter_id", scooterId)
+        reserveUpdate.eq("scooter_id", normalizeScooterId(scooterId))
                 .eq("status", DomainConstants.ScooterStatus.AVAILABLE)
                 .set("status", DomainConstants.ScooterStatus.RESERVED)
                 .set("updated_at", LocalDateTime.now())
@@ -279,20 +517,90 @@ public class BookingServiceImpl implements BookingService {
 
     private void releaseScooter(String scooterId) {
         UpdateWrapper<ScooterEntity> releaseUpdate = new UpdateWrapper<>();
-        releaseUpdate.eq("scooter_id", scooterId)
-                .eq("status", DomainConstants.ScooterStatus.RESERVED)
+        releaseUpdate.eq("scooter_id", normalizeScooterId(scooterId))
+                .in("status", DomainConstants.ScooterStatus.RESERVED, DomainConstants.ScooterStatus.IN_USE)
                 .set("status", DomainConstants.ScooterStatus.AVAILABLE)
                 .set("updated_at", LocalDateTime.now())
                 .setSql("version = version + 1");
         scooterMapper.update(null, releaseUpdate);
     }
 
+    private void setScooterStatus(String scooterId, String status) {
+        UpdateWrapper<ScooterEntity> updateWrapper = new UpdateWrapper<>();
+        updateWrapper.eq("scooter_id", normalizeScooterId(scooterId))
+                .set("status", status)
+                .set("updated_at", LocalDateTime.now())
+                .setSql("version = version + 1");
+        scooterMapper.update(null, updateWrapper);
+    }
+
+    private String normalizeScooterId(String scooterId) {
+        if (!hasText(scooterId)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "scooterId is required");
+        }
+        return scooterId.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private String normalizeBookingStatus(String status) {
+        String normalized = requireText(status, "status").toUpperCase(Locale.ROOT);
+        if (!Set.of(
+                DomainConstants.BookingStatus.PENDING_PAYMENT,
+                DomainConstants.BookingStatus.CONFIRMED,
+                DomainConstants.BookingStatus.ACTIVE,
+                DomainConstants.BookingStatus.COMPLETED,
+                DomainConstants.BookingStatus.CANCELLED,
+                DomainConstants.BookingStatus.EXPIRED
+        ).contains(normalized)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "Invalid booking status");
+        }
+        return normalized;
+    }
+
+    private String normalizePaymentStatus(String status) {
+        String normalized = requireText(status, "paymentStatus").toUpperCase(Locale.ROOT);
+        if (!Set.of(
+                DomainConstants.PAYMENT_STATUS_UNPAID,
+                DomainConstants.PAYMENT_STATUS_PAID,
+                DomainConstants.PAYMENT_STATUS_PARTIAL,
+                DomainConstants.PAYMENT_STATUS_REFUNDED
+        ).contains(normalized)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, "Invalid payment status");
+        }
+        return normalized;
+    }
+
+    private String requireText(String value, String field) {
+        if (!hasText(value)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        return value.trim();
+    }
+
+    private String requireText(Object value, String field) {
+        if (value == null || String.valueOf(value).trim().isEmpty()) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, field + " is required");
+        }
+        return String.valueOf(value).trim();
+    }
+
+    private String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
     private String newBookingId() {
-        return "BKG-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        return "BKG-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase(Locale.ROOT);
     }
 
     private String newBookingRef() {
-        return "REF-" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+        return "REF-" + UUID.randomUUID().toString().replace("-", "").substring(0, 10).toUpperCase(Locale.ROOT);
     }
 
     private PriceBreakdownVo toPriceBreakdown(BigDecimal base, BigDecimal discount, BigDecimal finalPrice) {
@@ -307,6 +615,7 @@ public class BookingServiceImpl implements BookingService {
         BookingListItemVo vo = new BookingListItemVo();
         vo.setBookingId(booking.getBookingId());
         vo.setBookingRef(booking.getBookingRef());
+        vo.setCustomerType(booking.getCustomerType());
         vo.setScooterId(booking.getScooterId());
         vo.setHireOptionId(booking.getHireOptionId());
         vo.setStatus(booking.getStatus());
@@ -324,11 +633,16 @@ public class BookingServiceImpl implements BookingService {
         vo.setBookingRef(booking.getBookingRef());
         vo.setCustomerType(booking.getCustomerType());
         vo.setUserId(booking.getUserId());
+        vo.setGuestName(booking.getGuestName());
+        vo.setGuestEmail(booking.getGuestEmail());
+        vo.setGuestPhone(booking.getGuestPhone());
         vo.setScooterId(booking.getScooterId());
         vo.setHireOptionId(booking.getHireOptionId());
         vo.setStatus(booking.getStatus());
         vo.setStartAt(booking.getStartAt());
         vo.setEndAt(booking.getEndAt());
+        vo.setActualStartAt(booking.getActualStartAt());
+        vo.setActualEndAt(booking.getActualEndAt());
         vo.setPriceBase(booking.getPriceBase());
         vo.setPriceDiscount(booking.getPriceDiscount());
         vo.setPriceFinal(booking.getPriceFinal());
@@ -339,7 +653,64 @@ public class BookingServiceImpl implements BookingService {
         return vo;
     }
 
+    private Map<String, Object> toBookingMap(BookingEntity booking) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("bookingId", booking.getBookingId());
+        data.put("bookingRef", booking.getBookingRef());
+        data.put("customerType", booking.getCustomerType());
+        data.put("userId", booking.getUserId());
+        data.put("guestName", booking.getGuestName());
+        data.put("guestEmail", booking.getGuestEmail());
+        data.put("guestPhone", booking.getGuestPhone());
+        data.put("scooterId", booking.getScooterId());
+        data.put("hireOptionId", booking.getHireOptionId());
+        data.put("status", booking.getStatus());
+        data.put("startAt", booking.getStartAt());
+        data.put("endAt", booking.getEndAt());
+        data.put("actualStartAt", booking.getActualStartAt());
+        data.put("actualEndAt", booking.getActualEndAt());
+        data.put("priceBase", booking.getPriceBase());
+        data.put("priceDiscount", booking.getPriceDiscount());
+        data.put("priceFinal", booking.getPriceFinal());
+        data.put("paymentStatus", booking.getPaymentStatus());
+        data.put("createdByRole", booking.getCreatedByRole());
+        data.put("cancelReason", booking.getCancelReason());
+        data.put("createdAt", booking.getCreatedAt());
+        data.put("updatedAt", booking.getUpdatedAt());
+        return data;
+    }
+
+    private Map<String, Object> toPaymentMap(PaymentEntity entity) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("paymentId", entity.getPaymentId());
+        data.put("bookingId", entity.getBookingId());
+        data.put("userId", entity.getUserId());
+        data.put("amount", entity.getAmount());
+        data.put("method", entity.getMethod());
+        data.put("paymentMethodId", entity.getPaymentMethodId());
+        data.put("status", entity.getStatus());
+        data.put("simulatedOutcome", entity.getSimulatedOutcome());
+        data.put("refundedAmount", entity.getRefundedAmount());
+        data.put("createdAt", entity.getCreatedAt());
+        data.put("updatedAt", entity.getUpdatedAt());
+        return data;
+    }
+
+    private String resolveConfirmationRecipient(BookingEntity booking) {
+        if (hasText(booking.getGuestEmail())) {
+            return booking.getGuestEmail();
+        }
+        BookingConfirmationEntity latest = bookingConfirmationMapper.selectOne(new LambdaQueryWrapper<BookingConfirmationEntity>()
+                .eq(BookingConfirmationEntity::getBookingId, booking.getBookingId())
+                .orderByDesc(BookingConfirmationEntity::getUpdatedAt)
+                .last("LIMIT 1"));
+        return latest == null ? null : latest.getRecipientEmail();
+    }
+
     private boolean hasText(String value) {
         return value != null && !value.trim().isEmpty();
+    }
+
+    private record PriceSnapshot(BigDecimal basePrice, BigDecimal discount, BigDecimal finalPrice) {
     }
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/impl/HireOptionServiceImpl.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/impl/HireOptionServiceImpl.java
@@ -9,7 +9,9 @@ import com.lcyhz.urbanova.domain.DomainConstants;
 import com.lcyhz.urbanova.dto.pricing.PriceQuoteRequest;
 import com.lcyhz.urbanova.entity.HireOptionEntity;
 import com.lcyhz.urbanova.mapper.HireOptionMapper;
+import com.lcyhz.urbanova.service.DiscountRuleService;
 import com.lcyhz.urbanova.service.HireOptionService;
+import com.lcyhz.urbanova.vo.pricing.AppliedDiscountVo;
 import com.lcyhz.urbanova.vo.hire.AdminHireOptionVo;
 import com.lcyhz.urbanova.vo.hire.HireOptionVo;
 import com.lcyhz.urbanova.vo.pricing.PriceQuoteVo;
@@ -28,6 +30,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class HireOptionServiceImpl implements HireOptionService {
     private final HireOptionMapper hireOptionMapper;
+    private final DiscountRuleService discountRuleService;
 
     @Override
     public List<HireOptionVo> listActiveHireOptions() {
@@ -38,7 +41,7 @@ public class HireOptionServiceImpl implements HireOptionService {
     }
 
     @Override
-    public PriceQuoteVo quotePrice(PriceQuoteRequest request) {
+    public PriceQuoteVo quotePrice(String userId, PriceQuoteRequest request) {
         HireOptionEntity option = hireOptionMapper.selectOne(new LambdaQueryWrapper<HireOptionEntity>()
                 .eq(HireOptionEntity::getCode, request.getHireOptionCode())
                 .eq(HireOptionEntity::getActive, 1));
@@ -46,10 +49,12 @@ public class HireOptionServiceImpl implements HireOptionService {
             throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Hire option not found");
         }
 
+        DiscountRuleService.DiscountComputation computation = discountRuleService.calculateForUser(userId, option.getBasePrice());
+
         PriceQuoteVo quoteVo = new PriceQuoteVo();
         quoteVo.setBasePrice(option.getBasePrice());
-        quoteVo.setAppliedDiscounts(Collections.emptyList());
-        quoteVo.setFinalPrice(option.getBasePrice().subtract(BigDecimal.ZERO));
+        quoteVo.setAppliedDiscounts(computation.appliedDiscounts() == null ? Collections.<AppliedDiscountVo>emptyList() : computation.appliedDiscounts());
+        quoteVo.setFinalPrice(computation.finalPrice());
         quoteVo.setCurrency(DomainConstants.CURRENCY_GBP);
         return quoteVo;
     }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/impl/ScooterServiceImpl.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/impl/ScooterServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -45,6 +46,43 @@ public class ScooterServiceImpl implements ScooterService {
 
     private final ScooterMapper scooterMapper;
     private final ScooterTypeMapper scooterTypeMapper;
+
+    @Override
+    public List<Map<String, Object>> listPublicScooters(String status, String typeCode, String zone) {
+        LambdaQueryWrapper<ScooterEntity> query = new LambdaQueryWrapper<ScooterEntity>()
+                .orderByAsc(ScooterEntity::getScooterId);
+        if (status != null && !status.isBlank()) {
+            query.eq(ScooterEntity::getStatus, normalizeScooterStatus(status));
+        }
+        if (typeCode != null && !typeCode.isBlank()) {
+            query.eq(ScooterEntity::getTypeCode, normalizeTypeCode(typeCode));
+        }
+        if (zone != null && !zone.isBlank()) {
+            query.eq(ScooterEntity::getZone, zone.trim());
+        }
+        Map<String, ScooterTypeEntity> typeMap = loadScooterTypeMap();
+        return scooterMapper.selectList(query).stream()
+                .map(entity -> toPublicScooterMap(entity, typeMap.get(entity.getTypeCode())))
+                .toList();
+    }
+
+    @Override
+    public Map<String, Object> getScooterDetail(String scooterId) {
+        ScooterEntity entity = findScooter(scooterId);
+        return toPublicScooterMap(entity, loadScooterTypeMap().get(entity.getTypeCode()));
+    }
+
+    @Override
+    public Map<String, Object> getAvailabilitySummary() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        for (String status : ALLOWED_STATUSES) {
+            long count = scooterMapper.selectCount(new LambdaQueryWrapper<ScooterEntity>()
+                    .eq(ScooterEntity::getStatus, status));
+            data.put(status, count);
+        }
+        data.put("total", scooterMapper.selectCount(new LambdaQueryWrapper<>()));
+        return data;
+    }
 
     @Override
     public ScooterIdsByStatusVo queryScooterIdsByStatus(String status) {
@@ -312,5 +350,25 @@ public class ScooterServiceImpl implements ScooterService {
         vo.setCreatedAt(entity.getCreatedAt());
         vo.setUpdatedAt(entity.getUpdatedAt());
         return vo;
+    }
+
+    private Map<String, Object> toPublicScooterMap(ScooterEntity entity, ScooterTypeEntity typeEntity) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("scooterId", entity.getScooterId());
+        data.put("typeCode", entity.getTypeCode());
+        if (typeEntity != null) {
+            data.put("typeDisplayName", typeEntity.getDisplayName());
+            data.put("typeImageUrl", typeEntity.getImageUrl());
+            data.put("typeDescription", typeEntity.getDescription());
+        }
+        data.put("status", entity.getStatus());
+        data.put("batteryPercent", entity.getBatteryPercent());
+        data.put("lat", entity.getLat());
+        data.put("lng", entity.getLng());
+        data.put("zone", entity.getZone());
+        data.put("version", entity.getVersion());
+        data.put("createdAt", entity.getCreatedAt());
+        data.put("updatedAt", entity.getUpdatedAt());
+        return data;
     }
 }

--- a/urbanova/src/main/java/com/lcyhz/urbanova/service/support/PlatformSupportService.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/service/support/PlatformSupportService.java
@@ -1,0 +1,255 @@
+package com.lcyhz.urbanova.service.support;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.lcyhz.urbanova.common.exception.BusinessException;
+import com.lcyhz.urbanova.common.exception.ErrorCodes;
+import com.lcyhz.urbanova.entity.AuditLogEntity;
+import com.lcyhz.urbanova.entity.BookingConfirmationEntity;
+import com.lcyhz.urbanova.entity.BookingEntity;
+import com.lcyhz.urbanova.entity.BookingEventEntity;
+import com.lcyhz.urbanova.entity.NotificationEntity;
+import com.lcyhz.urbanova.mapper.AuditLogMapper;
+import com.lcyhz.urbanova.mapper.BookingConfirmationMapper;
+import com.lcyhz.urbanova.mapper.BookingEventMapper;
+import com.lcyhz.urbanova.mapper.NotificationMapper;
+import com.lcyhz.urbanova.security.AuthContext;
+import com.lcyhz.urbanova.security.AuthUser;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class PlatformSupportService {
+    private final BookingEventMapper bookingEventMapper;
+    private final NotificationMapper notificationMapper;
+    private final BookingConfirmationMapper bookingConfirmationMapper;
+    private final AuditLogMapper auditLogMapper;
+
+    public PlatformSupportService(BookingEventMapper bookingEventMapper,
+                                  NotificationMapper notificationMapper,
+                                  BookingConfirmationMapper bookingConfirmationMapper,
+                                  AuditLogMapper auditLogMapper) {
+        this.bookingEventMapper = bookingEventMapper;
+        this.notificationMapper = notificationMapper;
+        this.bookingConfirmationMapper = bookingConfirmationMapper;
+        this.auditLogMapper = auditLogMapper;
+    }
+
+    public BookingEventEntity recordBookingEvent(String bookingId, String eventType, String actorUserId, String actorRole, String details) {
+        BookingEventEntity entity = new BookingEventEntity();
+        entity.setEventId(newPrefixedId("EVT", 10));
+        entity.setBookingId(bookingId);
+        entity.setEventType(eventType);
+        entity.setActorUserId(actorUserId);
+        entity.setActorRole(actorRole);
+        entity.setDetails(trimToNull(details));
+        entity.setCreatedAt(LocalDateTime.now());
+        bookingEventMapper.insert(entity);
+        return entity;
+    }
+
+    public NotificationEntity createNotification(String userId, String type, String title, String message, String relatedBookingId) {
+        if (!hasText(userId)) {
+            return null;
+        }
+        NotificationEntity entity = new NotificationEntity();
+        entity.setNotificationId(newPrefixedId("NTF", 10));
+        entity.setUserId(userId);
+        entity.setType(type);
+        entity.setTitle(limit(title, 120));
+        entity.setMessage(limit(message, 255));
+        entity.setReadFlag(0);
+        entity.setRelatedBookingId(trimToNull(relatedBookingId));
+        entity.setCreatedAt(LocalDateTime.now());
+        entity.setUpdatedAt(LocalDateTime.now());
+        notificationMapper.insert(entity);
+        return entity;
+    }
+
+    public BookingConfirmationEntity createOrRefreshConfirmation(BookingEntity booking,
+                                                                 String recipientEmail,
+                                                                 String channel,
+                                                                 String message,
+                                                                 boolean resend) {
+        BookingConfirmationEntity existing = bookingConfirmationMapper.selectOne(new LambdaQueryWrapper<BookingConfirmationEntity>()
+                .eq(BookingConfirmationEntity::getBookingId, booking.getBookingId())
+                .orderByDesc(BookingConfirmationEntity::getUpdatedAt)
+                .last("LIMIT 1"));
+
+        LocalDateTime now = LocalDateTime.now();
+        if (existing == null) {
+            BookingConfirmationEntity entity = new BookingConfirmationEntity();
+            entity.setConfirmationId(newPrefixedId("CNF", 10));
+            entity.setBookingId(booking.getBookingId());
+            entity.setUserId(booking.getUserId());
+            entity.setRecipientEmail(trimToNull(recipientEmail));
+            entity.setChannel(channel);
+            entity.setStatus(resend ? "RESENT" : "SENT");
+            entity.setMessage(limit(message, 255));
+            entity.setResendCount(resend ? 1 : 0);
+            entity.setCreatedAt(now);
+            entity.setUpdatedAt(now);
+            bookingConfirmationMapper.insert(entity);
+            return entity;
+        }
+
+        existing.setRecipientEmail(trimToNull(recipientEmail));
+        existing.setChannel(channel);
+        existing.setStatus(resend ? "RESENT" : "SENT");
+        existing.setMessage(limit(message, 255));
+        existing.setResendCount((existing.getResendCount() == null ? 0 : existing.getResendCount()) + (resend ? 1 : 0));
+        existing.setUpdatedAt(now);
+        bookingConfirmationMapper.updateById(existing);
+        return existing;
+    }
+
+    public void recordAudit(String action, String targetType, String targetId, String details) {
+        AuthUser authUser = AuthContext.getCurrentUser();
+        recordAudit(authUser == null ? null : authUser.getUserId(),
+                authUser == null ? "SYSTEM" : authUser.getRole(),
+                action,
+                targetType,
+                targetId,
+                details);
+    }
+
+    public void recordAudit(String actorUserId, String actorRole, String action, String targetType, String targetId, String details) {
+        AuditLogEntity entity = new AuditLogEntity();
+        entity.setAuditLogId(newPrefixedId("AUD", 10));
+        entity.setActorUserId(trimToNull(actorUserId));
+        entity.setActorRole(hasText(actorRole) ? actorRole : "SYSTEM");
+        entity.setAction(action);
+        entity.setTargetType(targetType);
+        entity.setTargetId(trimToNull(targetId));
+        entity.setDetails(limit(details, 255));
+        entity.setCreatedAt(LocalDateTime.now());
+        auditLogMapper.insert(entity);
+    }
+
+    public List<Map<String, Object>> listBookingTimeline(String bookingId) {
+        return bookingEventMapper.selectList(new LambdaQueryWrapper<BookingEventEntity>()
+                        .eq(BookingEventEntity::getBookingId, bookingId)
+                        .orderByAsc(BookingEventEntity::getCreatedAt))
+                .stream()
+                .map(this::toBookingEventMap)
+                .toList();
+    }
+
+    public List<Map<String, Object>> listNotifications(String userId) {
+        return notificationMapper.selectList(new LambdaQueryWrapper<NotificationEntity>()
+                        .eq(NotificationEntity::getUserId, userId)
+                        .orderByDesc(NotificationEntity::getCreatedAt))
+                .stream()
+                .map(this::toNotificationMap)
+                .toList();
+    }
+
+    public List<Map<String, Object>> listAuditLogs(String action, Integer limit) {
+        LambdaQueryWrapper<AuditLogEntity> query = new LambdaQueryWrapper<AuditLogEntity>()
+                .orderByDesc(AuditLogEntity::getCreatedAt);
+        if (hasText(action)) {
+            query.eq(AuditLogEntity::getAction, action.trim().toUpperCase(Locale.ROOT));
+        }
+        if (limit != null && limit > 0) {
+            query.last("LIMIT " + Math.min(limit, 200));
+        }
+        return auditLogMapper.selectList(query).stream().map(this::toAuditLogMap).toList();
+    }
+
+    public Map<String, Object> toBookingEventMap(BookingEventEntity entity) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("eventId", entity.getEventId());
+        data.put("bookingId", entity.getBookingId());
+        data.put("eventType", entity.getEventType());
+        data.put("actorUserId", entity.getActorUserId());
+        data.put("actorRole", entity.getActorRole());
+        data.put("details", entity.getDetails());
+        data.put("createdAt", entity.getCreatedAt());
+        return data;
+    }
+
+    public Map<String, Object> toNotificationMap(NotificationEntity entity) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("notificationId", entity.getNotificationId());
+        data.put("type", entity.getType());
+        data.put("title", entity.getTitle());
+        data.put("message", entity.getMessage());
+        data.put("read", entity.getReadFlag() != null && entity.getReadFlag() == 1);
+        data.put("relatedBookingId", entity.getRelatedBookingId());
+        data.put("createdAt", entity.getCreatedAt());
+        data.put("updatedAt", entity.getUpdatedAt());
+        return data;
+    }
+
+    public Map<String, Object> toConfirmationMap(BookingConfirmationEntity entity) {
+        if (entity == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND.value(), ErrorCodes.RESOURCE_NOT_FOUND, "Confirmation not found");
+        }
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("confirmationId", entity.getConfirmationId());
+        data.put("bookingId", entity.getBookingId());
+        data.put("userId", entity.getUserId());
+        data.put("recipientEmail", entity.getRecipientEmail());
+        data.put("channel", entity.getChannel());
+        data.put("status", entity.getStatus());
+        data.put("message", entity.getMessage());
+        data.put("resendCount", entity.getResendCount());
+        data.put("createdAt", entity.getCreatedAt());
+        data.put("updatedAt", entity.getUpdatedAt());
+        return data;
+    }
+
+    public Map<String, Object> toAuditLogMap(AuditLogEntity entity) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("auditLogId", entity.getAuditLogId());
+        data.put("actorUserId", entity.getActorUserId());
+        data.put("actorRole", entity.getActorRole());
+        data.put("action", entity.getAction());
+        data.put("targetType", entity.getTargetType());
+        data.put("targetId", entity.getTargetId());
+        data.put("details", entity.getDetails());
+        data.put("createdAt", entity.getCreatedAt());
+        return data;
+    }
+
+    public String requireText(Object value, String fieldName) {
+        if (value == null) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, fieldName + " is required");
+        }
+        String text = String.valueOf(value).trim();
+        if (text.isEmpty()) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), ErrorCodes.VALIDATION_ERROR, fieldName + " is required");
+        }
+        return text;
+    }
+
+    public String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    public boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    public String newPrefixedId(String prefix, int len) {
+        String raw = UUID.randomUUID().toString().replace("-", "").toUpperCase(Locale.ROOT);
+        return prefix + "-" + raw.substring(0, len);
+    }
+
+    private String limit(String value, int maxLen) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() <= maxLen ? value : value.substring(0, maxLen);
+    }
+}

--- a/urbanova/src/main/java/com/lcyhz/urbanova/vo/auth/AuthPayload.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/vo/auth/AuthPayload.java
@@ -4,9 +4,12 @@ import lombok.Data;
 
 @Data
 public class AuthPayload {
+    private String sessionId;
     private String accessToken;
+    private String refreshToken;
     private String tokenType;
     private long expiresInSeconds;
+    private long refreshExpiresInSeconds;
     private UserProfileVo user;
 }
 

--- a/urbanova/src/main/java/com/lcyhz/urbanova/vo/booking/BookingDetailVo.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/vo/booking/BookingDetailVo.java
@@ -11,11 +11,16 @@ public class BookingDetailVo {
     private String bookingRef;
     private String customerType;
     private String userId;
+    private String guestName;
+    private String guestEmail;
+    private String guestPhone;
     private String scooterId;
     private String hireOptionId;
     private String status;
     private LocalDateTime startAt;
     private LocalDateTime endAt;
+    private LocalDateTime actualStartAt;
+    private LocalDateTime actualEndAt;
     private BigDecimal priceBase;
     private BigDecimal priceDiscount;
     private BigDecimal priceFinal;

--- a/urbanova/src/main/java/com/lcyhz/urbanova/vo/booking/BookingListItemVo.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/vo/booking/BookingListItemVo.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 public class BookingListItemVo {
     private String bookingId;
     private String bookingRef;
+    private String customerType;
     private String scooterId;
     private String hireOptionId;
     private String status;

--- a/urbanova/src/main/java/com/lcyhz/urbanova/vo/booking/CreateBookingVo.java
+++ b/urbanova/src/main/java/com/lcyhz/urbanova/vo/booking/CreateBookingVo.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 public class CreateBookingVo {
     private String bookingId;
     private String status;
+    private String paymentStatus;
     private String scooterStatusSnapshot;
     private LocalDateTime startAt;
     private LocalDateTime endAt;

--- a/urbanova/src/main/resources/data.sql
+++ b/urbanova/src/main/resources/data.sql
@@ -9,6 +9,16 @@ ON DUPLICATE KEY UPDATE
     base_price = VALUES(base_price),
     active = VALUES(active);
 
+INSERT INTO discount_rules (discount_rule_id, type, threshold_hours_per_week, percentage, active)
+VALUES
+    ('DISC-FREQUENT', 'FREQUENT_USER', 8.00, 15.00, 1),
+    ('DISC-STUDENT', 'STUDENT', NULL, 10.00, 1),
+    ('DISC-SENIOR', 'SENIOR', NULL, 12.00, 1)
+ON DUPLICATE KEY UPDATE
+    threshold_hours_per_week = VALUES(threshold_hours_per_week),
+    percentage = VALUES(percentage),
+    active = VALUES(active);
+
 INSERT INTO scooter_types (type_code, display_name, image_url, description, active)
 VALUES
     ('ANDROMEDA', 'ANDROMEDA', '/images/scooter-types/andromeda.png', 'High-performance urban scooter.', 1),

--- a/urbanova/src/main/resources/schema.sql
+++ b/urbanova/src/main/resources/schema.sql
@@ -15,6 +15,35 @@ CREATE TABLE IF NOT EXISTS users (
     UNIQUE KEY uk_users_email (email)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS auth_sessions (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    session_id VARCHAR(40) NOT NULL,
+    user_id VARCHAR(36) NOT NULL,
+    refresh_token VARCHAR(128) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    revoked TINYINT(1) NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_auth_sessions_session_id (session_id),
+    UNIQUE KEY uk_auth_sessions_refresh_token (refresh_token),
+    KEY idx_auth_sessions_user_id (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    reset_token_id VARCHAR(40) NOT NULL,
+    user_id VARCHAR(36) NOT NULL,
+    reset_token VARCHAR(128) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    used TINYINT(1) NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_password_reset_tokens_reset_token_id (reset_token_id),
+    UNIQUE KEY uk_password_reset_tokens_reset_token (reset_token)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS hire_options (
     id BIGINT NOT NULL AUTO_INCREMENT,
     hire_option_id VARCHAR(40) NOT NULL,
@@ -27,6 +56,20 @@ CREATE TABLE IF NOT EXISTS hire_options (
     PRIMARY KEY (id),
     UNIQUE KEY uk_hire_options_hire_option_id (hire_option_id),
     UNIQUE KEY uk_hire_options_code (code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS discount_rules (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    discount_rule_id VARCHAR(40) NOT NULL,
+    type VARCHAR(30) NOT NULL,
+    threshold_hours_per_week DECIMAL(10,2) NULL,
+    percentage DECIMAL(5,2) NOT NULL,
+    active TINYINT(1) NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_discount_rules_discount_rule_id (discount_rule_id),
+    UNIQUE KEY uk_discount_rules_type (type)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS scooter_types (
@@ -60,16 +103,39 @@ CREATE TABLE IF NOT EXISTS scooters (
     CONSTRAINT fk_scooters_type_code FOREIGN KEY (type_code) REFERENCES scooter_types (type_code)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS payment_methods (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    payment_method_id VARCHAR(40) NOT NULL,
+    user_id VARCHAR(36) NOT NULL,
+    brand VARCHAR(20) NOT NULL,
+    last4 VARCHAR(4) NOT NULL,
+    expiry_month INT NOT NULL,
+    expiry_year INT NOT NULL,
+    label VARCHAR(60) NULL,
+    is_default TINYINT(1) NOT NULL DEFAULT 0,
+    status VARCHAR(20) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_payment_methods_payment_method_id (payment_method_id),
+    KEY idx_payment_methods_user_id (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS bookings (
     id BIGINT NOT NULL AUTO_INCREMENT,
     booking_id VARCHAR(32) NOT NULL,
     booking_ref VARCHAR(32) NOT NULL,
     customer_type VARCHAR(20) NOT NULL,
-    user_id VARCHAR(36) NOT NULL,
+    user_id VARCHAR(36) NULL,
+    guest_name VARCHAR(100) NULL,
+    guest_email VARCHAR(255) NULL,
+    guest_phone VARCHAR(30) NULL,
     scooter_id VARCHAR(32) NOT NULL,
     hire_option_id VARCHAR(40) NOT NULL,
     start_at DATETIME NOT NULL,
     end_at DATETIME NOT NULL,
+    actual_start_at DATETIME NULL,
+    actual_end_at DATETIME NULL,
     status VARCHAR(20) NOT NULL,
     price_base DECIMAL(10,2) NOT NULL,
     price_discount DECIMAL(10,2) NOT NULL,
@@ -85,4 +151,132 @@ CREATE TABLE IF NOT EXISTS bookings (
     KEY idx_bookings_user_id (user_id),
     KEY idx_bookings_scooter_id (scooter_id),
     KEY idx_bookings_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS payments (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    payment_id VARCHAR(40) NOT NULL,
+    booking_id VARCHAR(32) NOT NULL,
+    user_id VARCHAR(36) NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    method VARCHAR(20) NOT NULL,
+    payment_method_id VARCHAR(40) NULL,
+    status VARCHAR(20) NOT NULL,
+    simulated_outcome VARCHAR(20) NULL,
+    refunded_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_payments_payment_id (payment_id),
+    KEY idx_payments_booking_id (booking_id),
+    KEY idx_payments_user_id (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS booking_confirmations (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    confirmation_id VARCHAR(40) NOT NULL,
+    booking_id VARCHAR(32) NOT NULL,
+    user_id VARCHAR(36) NULL,
+    recipient_email VARCHAR(255) NULL,
+    channel VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    message VARCHAR(255) NOT NULL,
+    resend_count INT NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_booking_confirmations_confirmation_id (confirmation_id),
+    KEY idx_booking_confirmations_booking_id (booking_id),
+    KEY idx_booking_confirmations_user_id (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    notification_id VARCHAR(40) NOT NULL,
+    user_id VARCHAR(36) NOT NULL,
+    type VARCHAR(30) NOT NULL,
+    title VARCHAR(120) NOT NULL,
+    message VARCHAR(255) NOT NULL,
+    read_flag TINYINT(1) NOT NULL DEFAULT 0,
+    related_booking_id VARCHAR(32) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_notifications_notification_id (notification_id),
+    KEY idx_notifications_user_id (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS booking_events (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    event_id VARCHAR(40) NOT NULL,
+    booking_id VARCHAR(32) NOT NULL,
+    event_type VARCHAR(40) NOT NULL,
+    actor_user_id VARCHAR(36) NULL,
+    actor_role VARCHAR(20) NOT NULL,
+    details VARCHAR(255) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_booking_events_event_id (event_id),
+    KEY idx_booking_events_booking_id (booking_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS issues (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    issue_id VARCHAR(40) NOT NULL,
+    reporter_user_id VARCHAR(36) NOT NULL,
+    booking_id VARCHAR(32) NULL,
+    scooter_id VARCHAR(32) NULL,
+    title VARCHAR(120) NOT NULL,
+    description VARCHAR(500) NOT NULL,
+    priority VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    manager_feedback VARCHAR(255) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_issues_issue_id (issue_id),
+    KEY idx_issues_reporter_user_id (reporter_user_id),
+    KEY idx_issues_priority (priority),
+    KEY idx_issues_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS issue_comments (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    comment_id VARCHAR(40) NOT NULL,
+    issue_id VARCHAR(40) NOT NULL,
+    author_user_id VARCHAR(36) NULL,
+    author_role VARCHAR(20) NOT NULL,
+    message VARCHAR(500) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_issue_comments_comment_id (comment_id),
+    KEY idx_issue_comments_issue_id (issue_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    audit_log_id VARCHAR(40) NOT NULL,
+    actor_user_id VARCHAR(36) NULL,
+    actor_role VARCHAR(20) NOT NULL,
+    action VARCHAR(60) NOT NULL,
+    target_type VARCHAR(40) NOT NULL,
+    target_id VARCHAR(40) NULL,
+    details VARCHAR(500) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_audit_logs_audit_log_id (audit_log_id),
+    KEY idx_audit_logs_actor_user_id (actor_user_id),
+    KEY idx_audit_logs_action (action)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    idempotency_key VARCHAR(80) NOT NULL,
+    scope VARCHAR(80) NOT NULL,
+    request_hash VARCHAR(64) NULL,
+    response_code INT NULL,
+    response_ref VARCHAR(80) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_idempotency_keys_scope_key (scope, idempotency_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
feat(backend): complete remaining project backlog APIs and migrate MySQL schema

- implement auth/account extensions: refresh, logout, forgot/reset password, profile update, usage summary, and admin user management
- add saved payment method APIs with default-card support
- add discount eligibility and manager discount-rule management with quote-time discount preview
- expand scooter APIs with public list/detail/availability endpoints while keeping manager CRUD endpoints
- implement full booking lifecycle APIs: start, end, extend, timeline, staff guest bookings, and admin booking management
- add simulated payment flow with settlement, refund, confirmation, and notification support
- add issue/fault reporting workflow with comments, prioritization, resolution, and high-priority queue
- add manager analytics endpoints for revenue estimates, weekly hire-option totals, daily combined revenue, weekly chart data, and frequent-user insights
- add meta and audit-log endpoints and persist operational records in booking_events, notifications, confirmations, and audit_logs
- update schema.sql/data.sql and migrate the live MySQL database to add session, discount, payment, confirmation, notification, issue, audit, and idempotency tables plus guest/actual booking fields
- rewrite docs/API_DESIGN.md so the documented API matches the current implemented backend
- close #49 